### PR TITLE
[Fix] Horizontal <b-field> wrapped a simple text element with an extra <b-field>

### DIFF
--- a/src/components/field/FieldBody.vue
+++ b/src/components/field/FieldBody.vue
@@ -1,5 +1,5 @@
 <script>
-import { Comment, Fragment, h as createElement, resolveComponent } from 'vue'
+import { Comment, Fragment, Text, h as createElement, resolveComponent } from 'vue'
 
 export default {
     name: 'BFieldBody',
@@ -26,7 +26,7 @@ export default {
                 default: () => {
                     return children.map((element) => {
                         // skip returns(?) and comments
-                        if (element.type === Comment) {
+                        if (element.type === Comment || element.type === Text) {
                             return element
                         }
                         let message

--- a/src/components/field/FieldBody.vue
+++ b/src/components/field/FieldBody.vue
@@ -40,7 +40,7 @@ export default {
                                 type: this.type,
                                 message
                             },
-                            [element]
+                            () => element
                         )
                     })
                 }


### PR DESCRIPTION
Fixes
- close #5

Also addresses the issue pointed at in the following comment:
- https://github.com/ntohq/buefy/issues/1#issuecomment-1643034295

## Proposed Changes

- Return a text element as is
- Replace a direct child with a slot function