### PR TITLE
[Fix] <b-table> has an unexpected "tabindex" attribute containing "false"

### DIFF
--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -52,7 +52,7 @@
             <table
                 class="table"
                 :class="tableClasses"
-                :tabindex="!focusable ? false : 0"
+                :tabindex="!focusable ? undefined : 0"
                 @keydown.self.prevent.up="pressedArrow(-1)"
                 @keydown.self.prevent.down="pressedArrow(1)"
             >


### PR DESCRIPTION
Fixes
- close #8

## Proposed Changes

- Bind `tabindex` to `undefined` instead of `false` if `focusable` prop is `false` or not specified.