### PR TITLE
Fix BMenuList crash with "TypeError: slots.default is not a function"

### DIFF
--- a/src/components/menu/MenuList.vue
+++ b/src/components/menu/MenuList.vue
@@ -28,7 +28,7 @@ const BMenuList = (props, context) => {
             class: 'menu-list',
             role: props.ariaRole === 'menu' ? props.ariaRole : null
         },
-        slots.default()
+        typeof slots.default === 'function' ? slots.default() : slots.default
     )
     return vlabel ? [vlabel, vnode] : vnode
 }


### PR DESCRIPTION
- Fixes #20 

## Proposed Changes

- Make sure `slots.default` is a function before calling it