### PR TITLE
Fix potential cause: BFieldBody - TypeError: this.$slots.default is not a function

### DIFF
--- a/src/components/field/FieldBody.vue
+++ b/src/components/field/FieldBody.vue
@@ -15,8 +15,10 @@ export default {
         let first = true
         // wraps the default slot (children) with `b-field`.
         // children may be given in a fragment and should be extracted.
-        let children = this.$slots.default()
-        if (children.length === 1 && children[0].type === Fragment) {
+        let children = typeof this.$slots.default === 'function'
+            ? this.$slots.default()
+            : this.$slots.default
+        if (children != null && children.length === 1 && children[0].type === Fragment) {
             children = children[0].children
         }
         return createElement(
@@ -24,7 +26,7 @@ export default {
             { class: 'field-body' },
             {
                 default: () => {
-                    return children.map((element) => {
+                    return children != null && children.map((element) => {
                         // skip returns(?) and comments
                         if (element.type === Comment || element.type === Text) {
                             return element


### PR DESCRIPTION
Fixes a potential cause of
- #18

But there might be other reasons.

## Proposed Changes

- Make sure `this.$slots.default` is a function before calling it
- Make sure `this.$slots.default` is not nullish before accessing its fields