### PR TITLE
Fix: BNavbar crash with "TypeError: this.$slots.brand is not a function" (#28)

### DIFF
--- a/src/components/navbar/Navbar.vue
+++ b/src/components/navbar/Navbar.vue
@@ -168,10 +168,16 @@ export default {
             ])
         },
         genNavbarBrandNode() {
+            let children
+            if (this.$slots.brand != null) {
+                children = [this.$slots.brand(), this.genBurgerNode()]
+            } else {
+                children = this.genBurgerNode()
+            }
             return createElement(
                 'div',
                 { class: 'navbar-brand' },
-                [this.$slots.brand(), this.genBurgerNode()]
+                children
             )
         },
         genBurgerNode() {

--- a/src/components/navbar/Navbar.vue
+++ b/src/components/navbar/Navbar.vue
@@ -168,12 +168,9 @@ export default {
             ])
         },
         genNavbarBrandNode() {
-            let children
-            if (this.$slots.brand != null) {
-                children = [this.$slots.brand(), this.genBurgerNode()]
-            } else {
-                children = this.genBurgerNode()
-            }
+            const children = this.$slots.brand != null
+                ? [this.$slots.brand(), this.genBurgerNode()]
+                : this.genBurgerNode()
             return createElement(
                 'div',
                 { class: 'navbar-brand' },


### PR DESCRIPTION
Fixes:
- #28 

## Proposed Changes

- Check if `this.$slots.brand` is not nullish before calling it