### PR TITLE
Fix: unexpected "aria-expanded" on closed burger menu of BNavbar

### DIFF
--- a/src/components/navbar/NavbarBurger.vue
+++ b/src/components/navbar/NavbarBurger.vue
@@ -4,7 +4,7 @@
         class="navbar-burger burger"
         :class="{ 'is-active': isOpened }"
         aria-label="menu"
-        :aria-expanded="isOpened"
+        :aria-expanded="isOpened || undefined"
         v-bind="$attrs"
         tabindex="0"
     >


### PR DESCRIPTION
Fixes:
- #29

## Proposed Changes

- Bind `aria-expanded` to `undefined` instead of `false` when the burger menu is not opened