### PR TITLE
Fix: BFieldBody cannot resolve BField (#36)

### DIFF
--- a/src/components/field/FieldBody.vue
+++ b/src/components/field/FieldBody.vue
@@ -3,6 +3,12 @@ import { Comment, Fragment, Text, h as createElement, resolveComponent } from 'v
 
 export default {
     name: 'BFieldBody',
+    inject: {
+        parent: {
+            from: 'BField',
+            default: null
+        }
+    },
     props: {
         message: {
             type: [String, Array]
@@ -37,7 +43,7 @@ export default {
                             first = false
                         }
                         return createElement(
-                            resolveComponent('b-field'),
+                            this.parent ? this.parent.$.type : resolveComponent('b-field'),
                             {
                                 type: this.type,
                                 message


### PR DESCRIPTION
Fixes
- #36

## Proposed Changes

- Indirectly resolve `Field` component via an injected parent `Field` instance to avoid circular dependency
- Fall back to `resolveComponent('b-field')`
- Depend on Vue 3's internal structure (`$` to access component internals), though, I do not think Vue would break this anytime soon