### PR TITLE
Fix: BSlotComponent crashed with "TypeError: Cannot read properties of undefined (reading 'default')" (#44)

### DIFF
--- a/src/utils/SlotComponent.js
+++ b/src/utils/SlotComponent.js
@@ -44,8 +44,10 @@ export default {
     },
     render() {
         return createElement(this.tag, {},
-            this.scoped
-                ? this.component.$slots[this.name](this.props)
-                : this.component.$slots[this.name]())
+            this.component.$slots
+                ? this.scoped
+                    ? this.component.$slots[this.name](this.props)
+                    : this.component.$slots[this.name]()
+                : undefined)
     }
 }


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes
- #44

## Proposed Changes

- Make sure the underlying component has `$slots` before accessing it