### PR TITLE
Fix: BPaginationButton has unexpected aria-current with false (#39)

### DIFF
--- a/src/components/pagination/PaginationButton.vue
+++ b/src/components/pagination/PaginationButton.vue
@@ -9,7 +9,7 @@
         v-bind="$attrs"
         @click.prevent="page.click"
         :aria-label="page['aria-label']"
-        :aria-current="page.isCurrent"
+        :aria-current="page.isCurrent || undefined"
     >
         <slot>{{ page.number }}</slot>
     </component>


### PR DESCRIPTION
Fixes
- #39

## Proposed Changes

- Set `undefined` instead of `false` if the associated page is not current