### PR TITLE
Fix: BTabs does not respond to key interactions (#42)

### DIFF
--- a/src/components/tabs/Tabs.vue
+++ b/src/components/tabs/Tabs.vue
@@ -115,6 +115,14 @@ export default {
     },
     methods: {
         giveFocusToTab(tab) {
+            if (Array.isArray(tab)) {
+                // Vue ≥ v3.0 < v3.2.25, refs in v-for are stored as a single object,
+                // but ≥ v3.2.25, refs in v-for are stored in an array (same as Vue 2)
+                tab = tab[0]
+                if (tab == null) {
+                    return
+                }
+            }
             if (tab.$el && tab.$el.focus) {
                 tab.$el.focus()
             } else if (tab.focus) {


### PR DESCRIPTION
Fixes 
- #42

## Proposed Changes

- Check if tab items are stored in an array in `$refs` and extract the element if so