### PR TITLE
Port spec for Input

### DIFF
--- a/docs/pages/components/input/examples/ExSimple.vue
+++ b/docs/pages/components/input/examples/ExSimple.vue
@@ -29,6 +29,10 @@
         <b-field label="Message">
             <b-input maxlength="200" type="textarea"></b-input>
         </b-field>
+
+        <b-field label="Placeholder and Readonly">
+            <b-input placeholder="Awesome!" :readonly="true"></b-input>
+        </b-field>
     </section>
 </template>
 

--- a/src/components/input/Input.spec.js
+++ b/src/components/input/Input.spec.js
@@ -14,33 +14,33 @@ describe('BInput', () => {
     })
 
     it('is vue instance', () => {
-        expect(wrapper.name()).toBe('BInput')
-        expect(wrapper.isVueInstance()).toBeTruthy()
+        expect(wrapper.vm).toBeTruthy()
+        expect(wrapper.vm.$options.name).toBe('BInput')
     })
 
     it('renders input element by default', () => {
-        expect(wrapper.contains('input')).toBeTruthy()
+        expect(wrapper.find('input').exists()).toBeTruthy()
         expect(wrapper.classes()).toContain('control')
     })
 
-    it('render textarea element when type is textarea', () => {
-        wrapper.setProps({ type: 'textarea' })
+    it('render textarea element when type is textarea', async () => {
+        await wrapper.setProps({ type: 'textarea' })
         const target = wrapper.find('textarea')
 
         expect(target.exists()).toBeTruthy()
         expect(target.classes()).toContain('textarea')
     })
 
-    it('displays the icon when the icon property is true', () => {
-        wrapper.setProps({ icon: 'magnify' })
-        const target = wrapper.find(BIcon)
+    it('displays the icon when the icon property is true', async () => {
+        await wrapper.setProps({ icon: 'magnify' })
+        const target = wrapper.findComponent(BIcon)
 
         expect(target.exists()).toBeTruthy()
     })
 
-    it('display counter when the maxlength property is passed', () => {
-        wrapper.setProps({
-            value: 'foo',
+    it('display counter when the maxlength property is passed', async () => {
+        await wrapper.setProps({
+            modelValue: 'foo',
             maxlength: 100
         })
         const counter = wrapper.find('small.counter')
@@ -48,15 +48,15 @@ describe('BInput', () => {
         expect(counter.exists()).toBeTruthy()
         expect(counter.text()).toBe('3 / 100')
 
-        wrapper.setProps({
-            value: 1234
+        await wrapper.setProps({
+            modelValue: 1234
         })
         expect(counter.text()).toBe('4 / 100')
     })
 
-    it('display correct input value length when value contains some emoji', () => {
-        wrapper.setProps({
-            value: '😀2',
+    it('display correct input value length when value contains some emoji', async () => {
+        await wrapper.setProps({
+            modelValue: '😀2',
             maxlength: 5
         })
         const counter = wrapper.find('small.counter')
@@ -65,11 +65,11 @@ describe('BInput', () => {
         expect(counter.text()).toBe('2 / 5')
     })
 
-    it('no display counter when hasCounter property set for false', () => {
-        wrapper.setProps({ maxlength: 100 })
+    it('no display counter when hasCounter property set for false', async () => {
+        await wrapper.setProps({ maxlength: 100 })
         expect(wrapper.find('small.counter').exists()).toBeTruthy()
 
-        wrapper.setProps({ hasCounter: false })
+        await wrapper.setProps({ hasCounter: false })
         expect(wrapper.find('small.counter').exists()).toBeFalsy()
     })
 
@@ -86,16 +86,16 @@ describe('BInput', () => {
         expect(target.attributes().type).toBe('password')
     })
 
-    it('toggles the visibility of the password to true when the togglePasswordVisibility method is called', (done) => {
+    it('toggles the visibility of the password to true when the togglePasswordVisibility method is called', async (done) => {
         const wrapper = mount(BInput, {
-            propsData: {
-                value: 'foo',
+            props: {
+                modelValue: 'foo',
                 type: 'password',
                 passwordReveal: true
             }
         })
 
-        wrapper.setProps({ value: 'bar' })
+        await wrapper.setProps({ value: 'bar' })
 
         expect(wrapper.find('input').exists()).toBeTruthy()
         expect(wrapper.vm.newType).toBe('password')
@@ -105,7 +105,7 @@ describe('BInput', () => {
         const visibilityIcon = wrapper.find('.icon.is-clickable')
         expect(visibilityIcon.exists()).toBeTruthy()
         visibilityIcon.trigger('click')
-        wrapper.setProps({ passwordReveal: false })
+        await wrapper.setProps({ passwordReveal: false })
         expect(wrapper.vm.newType).toBe('text')
         expect(wrapper.vm.isPasswordVisible).toBeTruthy()
         expect(wrapper.find('input').attributes().type).toBe('text')
@@ -120,17 +120,17 @@ describe('BInput', () => {
         const target = wrapper.find('input')
 
         expect(target.element.getAttribute('placeholder')).toBe('Awesome!')
-        expect(target.element.getAttribute('readonly')).toBe('readonly')
+        expect(target.element.getAttribute('readonly')).toBe('')
     })
 
-    it('expands input when expanded property is passed', () => {
-        wrapper.setProps({ expanded: true })
+    it('expands input when expanded property is passed', async () => {
+        await wrapper.setProps({ expanded: true })
 
         expect(wrapper.classes()).toContain('is-expanded')
     })
 
-    it('display loading icon when loading property passed', () => {
-        wrapper.setProps({
+    it('display loading icon when loading property passed', async () => {
+        await wrapper.setProps({
             loading: true,
             icon: 'magnify'
         })
@@ -140,11 +140,15 @@ describe('BInput', () => {
 
     it('keep its value on blur', async () => {
         const wrapper = mount(BInput, {
-            propsData: {
-                value: 'foo'
-            },
-            methods: {
-                checkHtml5Validity: () => true
+            props: {
+                modelValue: 'foo',
+                // overriding the method `checkHtml5Validity` won't work
+                // because `mount` no longer accepts `methods` option on
+                // @vue/test-utils V2
+                //
+                // kikuomax: I decided to disable validation instead.
+                // I do not think it matters to the outcome anyway.
+                useHtml5Validation: false
             }
         })
 
@@ -157,24 +161,28 @@ describe('BInput', () => {
         expect(input.element.value).toBe('bar')
     })
 
-    it('change status icon when statusType updated', () => {
+    it('change status icon when statusType updated', async () => {
         const parent = {
             data: () => ({
                 newType: 'is-success',
+                // the following internal property is required
+                // so that a child Input can locate the parent (this component)
+                // and fetch `newType` from it.
+                // see `FormElementMixin` for more details
                 _isField: true
             }),
-            components: {BInput},
-            template: `<b-input />`
+            components: { BInput },
+            template: '<b-input />'
         }
         const wrapper = mount(parent)
 
-        const input = wrapper.find(BInput)
+        const input = wrapper.findComponent(BInput)
         expect(input.vm.statusTypeIcon).toBe('check')
-        wrapper.setData({ newType: 'is-danger' })
+        await wrapper.setData({ newType: 'is-danger' })
         expect(input.vm.statusTypeIcon).toBe('alert-circle')
-        wrapper.setData({ newType: 'is-info' })
+        await wrapper.setData({ newType: 'is-info' })
         expect(input.vm.statusTypeIcon).toBe('information')
-        wrapper.setData({ newType: 'is-warning' })
+        await wrapper.setData({ newType: 'is-warning' })
         expect(input.vm.statusTypeIcon).toBe('alert')
     })
 

--- a/src/components/input/__snapshots__/Input.spec.js.snap
+++ b/src/components/input/__snapshots__/Input.spec.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BInput render correctly 1`] = `
-<div class="control is-clearfix"><input type="text" autocomplete="on" class="input">
-    <!---->
-    <!---->
-    <!---->
+<div class="control is-clearfix"><input class="input" type="text" autocomplete="on">
+  <!--v-if-->
+  <!--v-if-->
+  <!--v-if-->
 </div>
 `;


### PR DESCRIPTION
Part of the series of PRs to port unit tests.

The following command should pass:
```sh
npx jest src/components/input
```

Related to:
- #1

## Proposed Changes

- Port spec for Input
- Add an example to `docs` to see the real behavior