### PR TITLE
Port spec for Table

### DIFF
--- a/src/components/table/TableColumn.spec.js
+++ b/src/components/table/TableColumn.spec.js
@@ -17,11 +17,11 @@ const WrapperComp = {
 
 describe('BTableColumn', () => {
     beforeEach(() => {
-        wrapper = mount(WrapperComp, { sync: false }).find({ ref: 'testItem' })
+        wrapper = mount(WrapperComp).findComponent({ ref: 'testItem' })
     })
 
     it('is called', () => {
-        expect(wrapper.name()).toBe('BTableColumn')
-        expect(wrapper.isVueInstance()).toBeTruthy()
+        expect(wrapper.vm).toBeTruthy()
+        expect(wrapper.vm.$options.name).toBe('BTableColumn')
     })
 })

--- a/src/components/table/TableMobileSort.spec.js
+++ b/src/components/table/TableMobileSort.spec.js
@@ -5,12 +5,12 @@ let wrapper
 
 describe('BTableMobileSort', () => {
     beforeEach(() => {
-        wrapper = shallowMount(BTableMobileSort, {sync: false})
+        wrapper = shallowMount(BTableMobileSort)
     })
 
     it('is called', () => {
-        expect(wrapper.name()).toBe('BTableMobileSort')
-        expect(wrapper.isVueInstance()).toBeTruthy()
+        expect(wrapper.vm).toBeTruthy()
+        expect(wrapper.vm.$options.name).toBe('BTableMobileSort')
     })
 
     it('render correctly', () => {
@@ -23,18 +23,15 @@ describe('BTableMobileSort', () => {
         })
     })
 
-    it('set mobileSort value when currentSortColumn is changed', (done) => {
-        wrapper.setProps({currentSortColumn: 'val'})
-        wrapper.vm.$nextTick(() => {
-            expect(wrapper.vm.mobileSort).toEqual(wrapper.vm.currentSortColumn)
-            done()
-        })
+    it('set mobileSort value when currentSortColumn is changed', async () => {
+        await wrapper.setProps({ currentSortColumn: 'val' })
+        expect(wrapper.vm.mobileSort).toEqual(wrapper.vm.currentSortColumn)
     })
 
     it('emit sort event with mobileSort value when sort is called', () => {
         wrapper.vm.mobileSort = 'val'
         wrapper.vm.sort()
-        const valueEmitted = wrapper.emitted()['sort'][0]
+        const valueEmitted = wrapper.emitted().sort[0]
         expect(valueEmitted).toContainEqual(wrapper.vm.mobileSort)
     })
 })

--- a/src/components/table/TableMobileSort.vue
+++ b/src/components/table/TableMobileSort.vue
@@ -128,7 +128,7 @@ export default {
             sortMultipleSelect: '',
             sortMultipleSelectIndex: -1,
             mobileSort: this.currentSortColumn,
-            mobileSortIndex: this.columns.indexOf(this.currentSortColumn),
+            mobileSortIndex: this.columns ? this.columns.indexOf(this.currentSortColumn) : -1,
             defaultEvent: {
                 shiftKey: true,
                 altKey: true,
@@ -168,12 +168,14 @@ export default {
         mobileSortIndex(index) {
             if (index !== -1) {
                 this.mobileSort = this.columns[index]
-            } else {
-                this.mobileSort = null
             }
+            // `index` becomes -1 if `currentSortColumn` is not in `columns`
+            // never resets to null but retains `mobileSort` in that case
         },
         currentSortColumn(column) {
-            this.mobileSortIndex = this.columns.indexOf(column)
+            // replaces `mobileSort` whether `column` is in `columns` or not
+            this.mobileSort = column
+            this.mobileSortIndex = this.columns ? this.columns.indexOf(column) : -1
         },
         columns(newColumns) {
             if (this.sortMultiple) {

--- a/src/components/table/__snapshots__/Table.spec.js.snap
+++ b/src/components/table/__snapshots__/Table.spec.js.snap
@@ -2,21 +2,21 @@
 
 exports[`BTable render correctly 1`] = `
 <div class="b-table">
-    <!---->
-    <!---->
-    <div class="table-wrapper has-mobile-cards">
-        <table class="table">
-            <!---->
-            <!---->
-            <tbody>
-                <tr class="is-empty">
-                    <td colspan="0"></td>
-                </tr>
-            </tbody>
-            <!---->
-        </table>
-        <!---->
-    </div>
-    <!---->
+  <!--v-if-->
+  <!--v-if-->
+  <div class="table-wrapper has-mobile-cards">
+    <table class="table">
+      <!--v-if-->
+      <!--v-if-->
+      <tbody>
+        <tr class="is-empty">
+          <td colspan="0"></td>
+        </tr>
+      </tbody>
+      <!--v-if-->
+    </table>
+    <!--v-if-->
+  </div>
+  <!--v-if-->
 </div>
 `;

--- a/src/components/table/__snapshots__/TableMobileSort.spec.js.snap
+++ b/src/components/table/__snapshots__/TableMobileSort.spec.js.snap
@@ -2,13 +2,11 @@
 
 exports[`BTableMobileSort render correctly 1`] = `
 <div class="field table-mobile-sort">
-    <div class="field has-addons">
-        <b-select-stub expanded="true" usehtml5validation="true" statusicon="true">
-            <!---->
-        </b-select-stub>
-        <div class="control"><button class="button is-primary">
-                <b-icon-stub icon="arrow-up" size="is-small" both="true" class="is-desc"></b-icon-stub>
-            </button></div>
-    </div>
+  <div class="field has-addons">
+    <b-select-stub modelvalue="-1" multiple="false" expanded=""></b-select-stub>
+    <div class="control"><button class="button is-primary">
+        <b-icon-stub icon="arrow-up" size="is-small" both="true" class="is-desc"></b-icon-stub>
+      </button></div>
+  </div>
 </div>
 `;


### PR DESCRIPTION
Part of the series of PRs to port unit tests.

The following command should pass:
```sh
npx jest src/components/table
```

You will see the following warning, though, this should happen only in the test environment:
> [Vue warn]: Invalid prop: type check failed for prop "currentSortColumn". Expected Object, got String with value "val".

Related to:
- #1

## Proposed Changes

- Port spec for Table
- Port spec for TableColumn
- Port spec for TableMobileSort
- Fix a test-specific issue on TableMobileSort