### PR TITLE
Port spec for Toast

### DIFF
--- a/src/components/toast/Toast.spec.js
+++ b/src/components/toast/Toast.spec.js
@@ -1,20 +1,68 @@
+import { transformVNodeArgs } from 'vue'
 import { shallowMount } from '@vue/test-utils'
-import BToast from '@components/toast/Toast'
+import { BToast, ToastProgrammatic } from '@components/toast'
 
 let wrapper
 
 describe('BToast', () => {
     HTMLElement.prototype.insertAdjacentElement = jest.fn()
     beforeEach(() => {
-        wrapper = shallowMount(BToast)
+        wrapper = shallowMount(
+            BToast,
+            {
+                global: {
+                    stubs: {
+                        // intentionally stubs transition
+                        // to avoid flaky snapshots
+                        transition: true
+                    }
+                }
+            }
+        )
     })
 
     it('is called', () => {
-        expect(wrapper.name()).toBe('BToast')
-        expect(wrapper.isVueInstance()).toBeTruthy()
+        expect(wrapper.vm).toBeTruthy()
+        expect(wrapper.vm.$options.name).toBe('BToast')
     })
 
     it('render correctly', () => {
         expect(wrapper.html()).toMatchSnapshot()
+    })
+
+    describe('programmatically opened', () => {
+        beforeEach(() => {
+            // resets stubs introduced by @vue/test-utils
+            // otherwise, every BToast is replaced with a stub
+            transformVNodeArgs(undefined)
+        })
+
+        it('should close after the duration', () => {
+            jest.useFakeTimers()
+            const params = {
+                message: 'message',
+                duration: 1000,
+                onClose: jest.fn()
+            }
+            ToastProgrammatic.open(params)
+            jest.advanceTimersByTime(500)
+            expect(params.onClose).not.toHaveBeenCalled()
+            jest.advanceTimersByTime(500)
+            expect(params.onClose).toHaveBeenCalled()
+        })
+
+        it('indefinitely should be able to be manually closed', () => {
+            jest.useFakeTimers()
+            const params = {
+                message: 'message',
+                indefinite: true,
+                onClose: jest.fn()
+            }
+            const toast = ToastProgrammatic.open(params)
+            jest.advanceTimersByTime(10000)
+            expect(params.onClose).not.toHaveBeenCalled()
+            toast.close()
+            expect(params.onClose).toHaveBeenCalled()
+        })
     })
 })

--- a/src/components/toast/__snapshots__/Toast.spec.js.snap
+++ b/src/components/toast/__snapshots__/Toast.spec.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BToast render correctly 1`] = `
-<div role="alert" class="toast is-dark is-top" style="" enter-active-class="fadeInDown" leave-active-class="fadeOut">
+<transition-stub enteractiveclass="fadeInDown" leaveactiveclass="fadeOut" appear="false" persisted="true" css="true">
+  <div class="toast is-dark is-top" aria-hidden="false" role="alert" style="">
     <div></div>
-</div>
+  </div>
+</transition-stub>
 `;


### PR DESCRIPTION
Part of the series of PRs to port unit tests.

The following command should pass:
```sh
npx jest src/components/toast
```

Related to:
- #1

## Proposed Changes

- Port spec for Toast
- Add new test cases to test programmatically opened Toast