### PR TITLE
Port spec for Modal

### DIFF
--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -14,7 +14,7 @@
             tabindex="-1"
             :role="ariaRole"
             :aria-label="ariaLabel"
-            :aria-modal="ariaModal"
+            :aria-modal="ariaModal || undefined"
         >
             <div class="modal-background" @click="cancel('outside')" />
             <div

--- a/src/components/modal/__snapshots__/Modal.spec.js.snap
+++ b/src/components/modal/__snapshots__/Modal.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`BModal render correctly 1`] = `
 <transition-stub name="zoom-out" appear="false" persisted="false" css="true">
-  <div class="modal is-active" tabindex="-1" aria-modal="false">
+  <div class="modal is-active" tabindex="-1">
     <div class="modal-background"></div>
     <div class="animation-content modal-content" style="max-width: 960px;"><button type="button" class="modal-close is-large"></button></div>
   </div>

--- a/src/components/modal/__snapshots__/Modal.spec.js.snap
+++ b/src/components/modal/__snapshots__/Modal.spec.js.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BModal render correctly 1`] = `
-<transition-stub name="zoom-out">
-    <div tabindex="-1" class="modal is-active">
-        <div class="modal-background"></div>
-        <div class="animation-content modal-content" style="max-width: 960px;"> <button type="button" class="modal-close is-large"></button></div>
-    </div>
+<transition-stub name="zoom-out" appear="false" persisted="false" css="true">
+  <div class="modal is-active" tabindex="-1" aria-modal="false">
+    <div class="modal-background"></div>
+    <div class="animation-content modal-content" style="max-width: 960px;"><button type="button" class="modal-close is-large"></button></div>
+  </div>
 </transition-stub>
 `;


### PR DESCRIPTION
Part of the series of PRs to port unit tests.

The following command should pass:
```sh
npx jest src/components/modal
```

Related to:
- #1

## Proposed Changes

- Port spec for Modal
- Add a test case to test programmatically opened Modal
- Fix a minor issue on Modal