### PR TITLE
Port spec for Icon

### DIFF
--- a/src/components/icon/Icon.spec.js
+++ b/src/components/icon/Icon.spec.js
@@ -11,13 +11,13 @@ describe('BIcon', () => {
     it('is vue instance', () => {
         const wrapper = shallowMount(BIcon)
 
-        expect(wrapper.name()).toBe('BIcon')
-        expect(wrapper.isVueInstance()).toBeTruthy()
+        expect(wrapper.vm).toBeTruthy()
+        expect(wrapper.vm.$options.name).toBe('BIcon')
     })
 
     it('render icon when icon property is passed', () => {
         const wrapper = shallowMount(BIcon, {
-            propsData: { icon: 'eye' }
+            props: { icon: 'eye' }
         })
 
         expect(wrapper.classes()).toContain('icon')
@@ -26,7 +26,7 @@ describe('BIcon', () => {
 
     it('render a colored icon when type is passed', () => {
         const wrapper = shallowMount(BIcon, {
-            propsData: {
+            props: {
                 icon: 'eye',
                 type: 'is-primary'
             }
@@ -37,9 +37,9 @@ describe('BIcon', () => {
 
     it('returns correct color for newType when type is passed as an object', () => {
         const wrapper = shallowMount(BIcon, {
-            propsData: {
+            props: {
                 icon: 'eye',
-                type: {'is-primary': true}
+                type: { 'is-primary': true }
             }
         })
 
@@ -48,7 +48,7 @@ describe('BIcon', () => {
 
     it('render icon package correctly when the pack property is is passed.', () => {
         const wrapper = shallowMount(BIcon, {
-            propsData: {
+            props: {
                 icon: 'eye',
                 pack: 'fa'
             }
@@ -57,63 +57,63 @@ describe('BIcon', () => {
         expect(wrapper.find('i').classes()).toContain('fa-eye')
     })
 
-    it('use both packages when the both property is is passed', () => {
+    it('use both packages when the both property is is passed', async () => {
         const wrapper = shallowMount(BIcon, {
-            propsData: {
+            props: {
                 icon: 'eye',
                 both: true
             }
         })
 
         expect(wrapper.find('i').classes()).toContain('mdi-eye')
-        wrapper.setProps({ pack: 'fa' })
+        await wrapper.setProps({ pack: 'fa' })
 
         const equivalentIcons = {
-            'check': 'check',
-            'information': 'info-circle',
+            check: 'check',
+            information: 'info-circle',
             'check-circle': 'check-circle',
-            'alert': 'exclamation-triangle',
+            alert: 'exclamation-triangle',
             'alert-circle': 'exclamation-circle',
             'arrow-up': 'arrow-up',
             'chevron-right': 'angle-right',
             'chevron-left': 'angle-left',
             'chevron-down': 'angle-down',
-            'eye': 'eye',
+            eye: 'eye',
             'eye-off': 'eye-slash',
             'menu-down': 'caret-down',
             'menu-up': 'caret-up',
-            'other': 'other'
+            other: 'other'
         }
 
-        const expectEquivalentIcon = (icon, expected) => {
-            wrapper.setProps({ icon })
+        const expectEquivalentIcon = async (icon, expected) => {
+            await wrapper.setProps({ icon })
             expect(wrapper.find('i').classes()).toContain(`fa-${expected}`)
         }
 
-        Object.keys(equivalentIcons).forEach((icon) => {
-            expectEquivalentIcon(icon, equivalentIcons[icon])
-        })
+        for (const icon in equivalentIcons) {
+            await expectEquivalentIcon(icon, equivalentIcons[icon])
+        }
     })
 
-    it('display size when size propery is passed', () => {
+    it('display size when size propery is passed', async () => {
         const wrapper = shallowMount(BIcon, {
-            propsData: {
+            props: {
                 icon: 'eye'
             }
         })
 
         expect(wrapper.find('i').classes()).toContain('mdi-24px')
-        wrapper.setProps({ size: 'is-small' })
+        await wrapper.setProps({ size: 'is-small' })
         expect(wrapper.find('i').classes()).toContainEqual('mdi', 'mdi-eye')
-        wrapper.setProps({ size: 'is-medium' })
+        await wrapper.setProps({ size: 'is-medium' })
         expect(wrapper.find('i').classes()).toContain('mdi-36px')
-        wrapper.setProps({ size: 'is-large' })
+        await wrapper.setProps({ size: 'is-large' })
         expect(wrapper.find('i').classes()).toContain('mdi-48px')
     })
 
     it('overrides icon font size when customSize property is passed', () => {
         const wrapper = shallowMount(BIcon, {
-            propsData: {
+            props: {
                 icon: 'eye',
                 pack: 'fa',
                 customSize: 'fa-2x'
@@ -125,7 +125,7 @@ describe('BIcon', () => {
 
     it('render custom classes when customClass property is passed', () => {
         const wrapper = shallowMount(BIcon, {
-            propsData: {
+            props: {
                 icon: 'eye',
                 customClass: 'foo-bar'
             }


### PR DESCRIPTION
Part of the series of PRs to port unit tests.

The following command should pass:
```sh
npx jest src/components/icon
```

Related to:
- #1

## Proposed Changes

- Port spec for Icon