### PR TITLE
Port spec for Tooltip

### DIFF
--- a/src/components/tooltip/Tooltip.spec.js
+++ b/src/components/tooltip/Tooltip.spec.js
@@ -4,13 +4,24 @@ import BTooltip from '@components/tooltip/Tooltip'
 let wrapper
 
 describe('BTooltip', () => {
+    let spyOnOnHover
+    let spyOnOnContextMenu
+    let spyOnOnFocus
+    let spyOnOpen
+
     beforeEach(() => {
+        // spies on methods before mounting the component
+        // because wrapper.vm does not allow spies
+        spyOnOnHover = jest.spyOn(BTooltip.methods, 'onHover')
+        spyOnOnContextMenu = jest.spyOn(BTooltip.methods, 'onContextMenu')
+        spyOnOnFocus = jest.spyOn(BTooltip.methods, 'onFocus')
+        spyOnOpen = jest.spyOn(BTooltip.methods, 'open')
         wrapper = shallowMount(BTooltip)
     })
 
     it('is called', () => {
-        expect(wrapper.name()).toBe('BTooltip')
-        expect(wrapper.isVueInstance()).toBeTruthy()
+        expect(wrapper.vm).toBeTruthy()
+        expect(wrapper.vm.$options.name).toBe('BTooltip')
     })
 
     it('render correctly', () => {
@@ -18,37 +29,33 @@ describe('BTooltip', () => {
     })
 
     it('tests isActive watch', async () => {
-        await wrapper.setProps({appendToBody: true})
-        wrapper.vm.updateAppendToBody = jest.fn()
-        wrapper.vm.isActive = true
+        await wrapper.setProps({ appendToBody: true })
+        await wrapper.setData({
+            updateAppendToBody: jest.fn(),
+            isActive: true
+        })
         expect(wrapper.vm.updateAppendToBody).toHaveBeenCalled()
         expect(wrapper.emitted().open).toBeTruthy()
     })
 
     it('tests onHover method', async () => {
-        const onHover = jest.spyOn(wrapper.vm, 'onHover')
-        const open = jest.spyOn(wrapper.vm, 'open')
-        await wrapper.setProps({triggers: ['hover']})
+        await wrapper.setProps({ triggers: ['hover'] })
         wrapper.vm.onHover()
-        expect(onHover).toHaveBeenCalled()
-        expect(open).toHaveBeenCalled()
+        expect(spyOnOnHover).toHaveBeenCalled()
+        expect(spyOnOpen).toHaveBeenCalled()
     })
 
     it('tests onContextMenu method', async () => {
-        const onContextMenu = jest.spyOn(wrapper.vm, 'onContextMenu')
-        const open = jest.spyOn(wrapper.vm, 'open')
-        await wrapper.setProps({triggers: ['contextmenu']})
-        wrapper.vm.onContextMenu({preventDefault: jest.fn()})
-        expect(onContextMenu).toHaveBeenCalled()
-        expect(open).toHaveBeenCalled()
+        await wrapper.setProps({ triggers: ['contextmenu'] })
+        wrapper.vm.onContextMenu({ preventDefault: jest.fn() })
+        expect(spyOnOnContextMenu).toHaveBeenCalled()
+        expect(spyOnOpen).toHaveBeenCalled()
     })
 
     it('tests onFocus method', async () => {
-        const onFocus = jest.spyOn(wrapper.vm, 'onFocus')
-        const open = jest.spyOn(wrapper.vm, 'open')
-        await wrapper.setProps({triggers: ['focus']})
+        await wrapper.setProps({ triggers: ['focus'] })
         wrapper.vm.onFocus()
-        expect(onFocus).toHaveBeenCalled()
-        expect(open).toHaveBeenCalled()
+        expect(spyOnOnFocus).toHaveBeenCalled()
+        expect(spyOnOpen).toHaveBeenCalled()
     })
 })

--- a/src/components/tooltip/Tooltip.vue
+++ b/src/components/tooltip/Tooltip.vue
@@ -268,7 +268,7 @@ export default {
         isInWhiteList(el) {
             if (el === this.$refs.content) return true
             // All chidren from content
-            if (this.$refs.content !== undefined) {
+            if (this.$refs.content != null) {
                 const children = this.$refs.content.querySelectorAll('*')
                 for (const child of children) {
                     if (el === child) {

--- a/src/components/tooltip/__snapshots__/Tooltip.spec.js.snap
+++ b/src/components/tooltip/__snapshots__/Tooltip.spec.js.snap
@@ -1,3 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BTooltip render correctly 1`] = `<span class="b-tooltip is-primary is-top is-medium"><div class="tooltip-content" style="display: none;" name="fade"><!----></div> <div class="tooltip-trigger"></div></span>`;
+exports[`BTooltip render correctly 1`] = `
+<div class="b-tooltip is-primary is-top is-medium">
+  <transition-stub name="fade" appear="false" persisted="true" css="true">
+    <div class="tooltip-content" style="display: none;">
+      <!--v-if-->
+    </div>
+  </transition-stub>
+  <div class="tooltip-trigger"></div>
+</div>
+`;


### PR DESCRIPTION
Part of the series of PRs to port unit tests.

The following command should pass:
```sh
npx jest src/components/tooltip
```

Related to:
- #1

## Proposed Changes

- Port spec for Tooltip
- Fix potential crash of Tooltip