### PR TITLE
Port spec for Datepicker

### DIFF
--- a/src/components/datepicker/Datepicker.spec.js
+++ b/src/components/datepicker/Datepicker.spec.js
@@ -1,7 +1,7 @@
 import { shallowMount } from '@vue/test-utils'
 import BDatepicker from '@components/datepicker/Datepicker'
 
-import config, {setOptions} from '@utils/config'
+import config, { setOptions } from '@utils/config'
 
 let wrapper, defaultProps
 
@@ -30,8 +30,10 @@ describe('BDatepicker', () => {
             }))
 
             wrapper = shallowMount(BDatepicker, {
-                stubs: {
-                    transition: false
+                global: {
+                    stubs: {
+                        transition: true
+                    }
                 }
             })
         })
@@ -66,11 +68,13 @@ describe('BDatepicker', () => {
         }
 
         wrapper = shallowMount(BDatepicker, {
-            propsData: {
+            props: {
                 ...defaultProps
             },
-            stubs: {
-                transition: false
+            global: {
+                stubs: {
+                    transition: true
+                }
             }
         })
 
@@ -79,12 +83,28 @@ describe('BDatepicker', () => {
     })
 
     it('is called', () => {
-        expect(wrapper.name()).toBe('BDatepicker')
-        expect(wrapper.isVueInstance()).toBeTruthy()
+        expect(wrapper.vm).toBeTruthy()
+        expect(wrapper.vm.$options.name).toBe('BDatepicker')
     })
 
     it('render correctly', () => {
-        wrapper.setProps({dateCreator: () => {}})
+        wrapper = shallowMount(BDatepicker, {
+            props: {
+                ...defaultProps
+            },
+            global: {
+                stubs: {
+                    transition: true,
+                    // reproduces a snapshot closer to the legacy one that
+                    // depends on default slots rendered even if stubbed
+                    bDropdown: false,
+                    bDropdownItem: false,
+                    bField: false,
+                    bSelect: false
+                }
+            }
+        })
+        wrapper.setProps({ dateCreator: () => {} })
         expect(wrapper.html()).toMatchSnapshot()
     })
 
@@ -99,7 +119,7 @@ describe('BDatepicker', () => {
         wrapper.vm.computedValue = date
         expect(wrapper.vm.updateInternalState).toHaveBeenCalledWith(date)
         expect(wrapper.vm.togglePicker).toHaveBeenCalled()
-        expect(wrapper.emitted()['input']).toBeTruthy()
+        expect(wrapper.emitted()['update:modelValue']).toBeTruthy()
     })
 
     it('react accordingly when handling native picker', () => {
@@ -107,28 +127,28 @@ describe('BDatepicker', () => {
         wrapper.vm.onChangeNativePicker({ target: { value: '2020-01-01' } })
         expect(wrapper.vm.updateInternalState).toHaveBeenCalledWith(date)
         expect(wrapper.vm.togglePicker).toHaveBeenCalled()
-        expect(wrapper.emitted()['input']).toBeTruthy()
+        expect(wrapper.emitted()['update:modelValue']).toBeTruthy()
     })
 
     it('react accordingly when handling native picker clear', () => {
         wrapper.vm.onChangeNativePicker({ target: { value: '' } })
         expect(wrapper.vm.updateInternalState).toHaveBeenCalledWith(null)
         expect(wrapper.vm.togglePicker).toHaveBeenCalled()
-        expect(wrapper.emitted()['input']).toEqual([[null]])
+        expect(wrapper.emitted()['update:modelValue']).toEqual([[null]])
     })
 
-    it('react accordingly when changing v-model', () => {
+    it('react accordingly when changing v-model', async () => {
         const date = new Date()
-        wrapper.setProps({
-            value: date
+        await wrapper.setProps({
+            modelValue: date
         })
         expect(wrapper.vm.updateInternalState).toHaveBeenCalledWith(date)
         expect(wrapper.vm.togglePicker).toHaveBeenCalled()
     })
 
-    it('set focusedDateData when changing focused date', () => {
+    it('set focusedDateData when changing focused date', async () => {
         const date = newDate(2019, 8, 26)
-        wrapper.setProps({
+        await wrapper.setProps({
             focusedDate: date
         })
         expect(wrapper.vm.focusedDateData).toEqual({
@@ -138,23 +158,23 @@ describe('BDatepicker', () => {
         })
     })
 
-    it('react accordingly when calling onChange', () => {
+    it('react accordingly when calling onChange', async () => {
         const date = new Date()
-        wrapper.setProps({dateParser: jest.fn()})
+        await wrapper.setProps({ dateParser: jest.fn() })
         wrapper.vm.onChange(date)
         expect(wrapper.vm.dateParser).toHaveBeenCalled()
     })
 
-    it('react accordingly when calling prev', () => {
+    it('react accordingly when calling prev', async () => {
         let date = newDate(2019, 8, 26)
-        wrapper.setProps({
+        await wrapper.setProps({
             focusedDate: date
         })
         wrapper.vm.prev()
         expect(wrapper.vm.focusedDateData.month).toBe(7)
 
         date = newDate(2019, 0, 26)
-        wrapper.setProps({
+        await wrapper.setProps({
             focusedDate: date
         })
         wrapper.vm.prev()
@@ -162,7 +182,7 @@ describe('BDatepicker', () => {
         expect(wrapper.vm.focusedDateData.month).toBe(11)
 
         date = newDate(2021, 1, 1)
-        wrapper.setProps({
+        await wrapper.setProps({
             focusedDate: date,
             type: 'month'
         })
@@ -170,7 +190,7 @@ describe('BDatepicker', () => {
         expect(wrapper.vm.focusedDateData.year).toBe(2020)
 
         date = newDate(2021, 1, 1)
-        wrapper.setProps({
+        await wrapper.setProps({
             focusedDate: date,
             type: 'month',
             disabled: true
@@ -179,16 +199,16 @@ describe('BDatepicker', () => {
         expect(wrapper.vm.focusedDateData.year).toBe(2021)
     })
 
-    it('react accordingly when calling next', () => {
+    it('react accordingly when calling next', async () => {
         let date = newDate(2019, 8, 26)
-        wrapper.setProps({
+        await wrapper.setProps({
             focusedDate: date
         })
         wrapper.vm.next()
         expect(wrapper.vm.focusedDateData.month).toBe(9)
 
         date = newDate(2019, 11, 26)
-        wrapper.setProps({
+        await wrapper.setProps({
             focusedDate: date
         })
         wrapper.vm.next()
@@ -196,7 +216,7 @@ describe('BDatepicker', () => {
         expect(wrapper.vm.focusedDateData.month).toBe(0)
 
         date = newDate(2021, 1, 1)
-        wrapper.setProps({
+        await wrapper.setProps({
             focusedDate: date,
             type: 'month'
         })
@@ -204,7 +224,7 @@ describe('BDatepicker', () => {
         expect(wrapper.vm.focusedDateData.year).toBe(2022)
 
         date = newDate(2021, 1, 1)
-        wrapper.setProps({
+        await wrapper.setProps({
             focusedDate: date,
             type: 'month',
             disabled: true
@@ -213,15 +233,15 @@ describe('BDatepicker', () => {
         expect(wrapper.vm.focusedDateData.year).toBe(2021)
     })
 
-    it('handles accordingly the list of months', () => {
-        wrapper.setProps({
+    it('handles accordingly the list of months', async () => {
+        await wrapper.setProps({
             focusedDate: newDate(2021, 10, 16),
             minDate: newDate(2021, 10, 15),
             maxDate: null
         })
         expect(wrapper.vm.listOfMonths.filter((month) => !month.disabled).map((month) => month.name)).toEqual(['November', 'December'])
 
-        wrapper.setProps({
+        await wrapper.setProps({
             focusedDate: newDate(2021, 2, 1),
             minDate: null,
             maxDate: newDate(2021, 2, 15)
@@ -229,8 +249,8 @@ describe('BDatepicker', () => {
         expect(wrapper.vm.listOfMonths.filter((month) => !month.disabled).map((month) => month.name)).toEqual(['January', 'February', 'March'])
     })
 
-    it('handles accordingly the list of years', () => {
-        wrapper.setProps({
+    it('handles accordingly the list of years', async () => {
+        await wrapper.setProps({
             minDate: newDate(2017, 1, 1),
             maxDate: null
         })
@@ -238,14 +258,14 @@ describe('BDatepicker', () => {
         for (let i = 1; i <= 11; i++) y.push(y[i - 1] + 1)
         expect(wrapper.vm.listOfYears).toEqual(y.reverse())
 
-        wrapper.setProps({
+        await wrapper.setProps({
             maxDate: newDate(2020, 1, 1)
         })
         expect(wrapper.vm.listOfYears.sort()).toEqual([2020, 2019, 2018, 2017].sort())
     })
 
-    it('handles accordingly focus', () => {
-        wrapper.setProps({
+    it('handles accordingly focus', async () => {
+        await wrapper.setProps({
             openOnFocus: false
         })
         wrapper.vm.onFocus = jest.fn()
@@ -255,7 +275,7 @@ describe('BDatepicker', () => {
         expect(wrapper.vm.onFocus).toHaveBeenCalled()
         expect(wrapper.vm.togglePicker).toHaveBeenCalledTimes(0)
 
-        wrapper.setProps({
+        await wrapper.setProps({
             openOnFocus: true
         })
         wrapper.vm.handleOnFocus()
@@ -264,19 +284,26 @@ describe('BDatepicker', () => {
     })
 
     describe('#dateFormatter', () => {
+        beforeEach(() => {
+            // uses en-US locale to make outputs predictable
+            wrapper.setProps({
+                locale: 'en-US'
+            })
+        })
+
         it('should add one to month since month in dates starts from 0', () => {
             const dateToFormat = new Date(2019, 3, 1)
             const formattedDate = wrapper.vm.dateFormatter(dateToFormat, wrapper.vm)
-            expect(formattedDate).toEqual('2019-4-1')
+            expect(formattedDate).toEqual('4/1/2019')
         })
 
-        it('should format based on 2-digit numeric locale date with type === month', () => {
-            wrapper.setProps({
+        it('should format based on 2-digit numeric locale date with type === month', async () => {
+            await wrapper.setProps({
                 type: 'month'
             })
-            const dateToFormat = new Date(2019, 3, 1)
+            const dateToFormat = new Date(2019, 3, 15)
             const formattedDate = wrapper.vm.dateFormatter(dateToFormat, wrapper.vm)
-            expect(formattedDate).toEqual('2019-04')
+            expect(formattedDate).toEqual('4/2019')
         })
 
         it('should format a range of dates passed via array', () => {
@@ -285,7 +312,7 @@ describe('BDatepicker', () => {
                 new Date(2019, 3, 3)
             ]
             const formattedDate = wrapper.vm.dateFormatter(dateToFormat, wrapper.vm)
-            expect(formattedDate).toEqual('2019-4-1 - 2019-4-3')
+            expect(formattedDate).toEqual('4/1/2019 - 4/3/2019')
         })
 
         describe('multiple', () => {
@@ -305,7 +332,7 @@ describe('BDatepicker', () => {
                     new Date(2019, 3, 3)
                 ]
                 const formattedDate = wrapper.vm.dateFormatter(dateToFormat, wrapper.vm)
-                expect(formattedDate).toEqual('2019-4-1, 2019-4-13, 2019-4-3')
+                expect(formattedDate).toEqual('4/1/2019, 4/13/2019, 4/3/2019')
             })
 
             it('react accordingly when setting computedValue', () => {
@@ -313,13 +340,13 @@ describe('BDatepicker', () => {
                 wrapper.vm.computedValue = date
                 expect(wrapper.vm.updateInternalState).toHaveBeenCalledWith(date)
                 expect(wrapper.vm.togglePicker).toHaveBeenCalledTimes(0)
-                expect(wrapper.emitted()['input']).toBeTruthy()
+                expect(wrapper.emitted()['update:modelValue']).toBeTruthy()
             })
 
-            it('react accordingly when changing v-model', () => {
+            it('react accordingly when changing v-model', async () => {
                 const date = new Date()
-                wrapper.setProps({
-                    value: date
+                await wrapper.setProps({
+                    modelValue: date
                 })
                 expect(wrapper.vm.updateInternalState).toHaveBeenCalledWith(date)
                 expect(wrapper.vm.togglePicker).toHaveBeenCalledTimes(0)
@@ -328,9 +355,9 @@ describe('BDatepicker', () => {
     })
 
     describe('#formatValue', () => {
-        it('should call dateFormatter, passing the date', () => {
+        it('should call dateFormatter, passing the date', async () => {
             const mockDateFormatter = jest.fn()
-            wrapper.setProps({
+            await wrapper.setProps({
                 dateFormatter: mockDateFormatter,
                 closeOnClick: false
             })
@@ -339,9 +366,9 @@ describe('BDatepicker', () => {
             expect(mockDateFormatter.mock.calls[0][0]).toEqual(date)
         })
 
-        it('should not call dateFormatter when value is undefined or NaN', () => {
+        it('should not call dateFormatter when value is undefined or NaN', async () => {
             const mockDateFormatter = jest.fn()
-            wrapper.setProps({
+            await wrapper.setProps({
                 dateFormatter: mockDateFormatter
             })
             wrapper.vm.formatValue(undefined)
@@ -350,9 +377,9 @@ describe('BDatepicker', () => {
             expect(mockDateFormatter.mock.calls.length).toEqual(0)
         })
 
-        it('should not call dateFormatter when value is an array with undefined or NaN elements', () => {
+        it('should not call dateFormatter when value is an array with undefined or NaN elements', async () => {
             const mockDateFormatter = jest.fn()
-            wrapper.setProps({
+            await wrapper.setProps({
                 dateFormatter: mockDateFormatter
             })
             wrapper.vm.formatValue([new Date(), undefined])
@@ -365,13 +392,18 @@ describe('BDatepicker', () => {
     describe('when horizontalTimePicker is true', () => {
         beforeEach(() => {
             wrapper = shallowMount(BDatepicker, {
-                stubs: {
-                    transition: false
+                global: {
+                    stubs: {
+                        transition: true,
+                        // tests depend on slots under BDropdown
+                        bDropdown: false,
+                        bDropdownItem: false
+                    }
                 },
                 slots: {
                     default: ['<div>Custom footer</div>']
                 },
-                propsData: {
+                props: {
                     horizontalTimePicker: true
                 }
             })

--- a/src/components/datepicker/DatepickerTableRow.vue
+++ b/src/components/datepicker/DatepickerTableRow.vue
@@ -16,7 +16,7 @@
                 class="datepicker-cell"
                 role="button"
                 href="#"
-                :disabled="disabled"
+                :disabled="disabled || undefined"
                 @click.prevent="emitChosenDate(weekDay)"
                 @mouseenter="setRangeHoverEndDate(weekDay)"
                 @keydown="manageKeydown($event, weekDay)"

--- a/src/components/datepicker/__snapshots__/Datepicker.spec.js.snap
+++ b/src/components/datepicker/__snapshots__/Datepicker.spec.js.snap
@@ -2,400 +2,53 @@
 
 exports[`BDatepicker render correctly 1`] = `
 <div class="datepicker control">
-    <b-dropdown-stub maxheight="200" triggers="click" mobilemodal="true" ariarole="dialog" animation="fade" trapfocus="true" closeonclick="true" canclose="true" appendtobodycopyparent="true" aria-modal="true">
-        <b-dropdown-item-stub custom="true" focusable="true" ariarole="" class="">
+  <div class="dropdown dropdown-menu-animation is-mobile-modal">
+    <div tabindex="-1" class="dropdown-trigger" aria-haspopup="true">
+      <b-input-stub type="text" lazy="false" passwordreveal="false" iconclickable="false" hascounter="true" customclass="" iconrightclickable="false" autocomplete="off" rounded="false" loading="false" readonly="" use-html5-validation="false"></b-input-stub>
+    </div>
+    <transition-stub name="fade" appear="false" persisted="false" css="true">
+      <div class="background" aria-hidden="true" style="display: none;"></div>
+    </transition-stub>
+    <transition-stub name="fade" appear="false" persisted="true" css="true">
+      <div class="dropdown-menu" aria-hidden="true" style="display: none;">
+        <div class="dropdown-content" role="dialog" aria-modal="true">
+          <div class="dropdown-item" tabindex="0">
             <div>
-                <header class="datepicker-header">
-                    <div class="pagination field is-centered"><a role="button" href="#" class="pagination-previous">
-                            <b-icon-stub type="is-primary is-clickable" icon="chevron-left" both="true"></b-icon-stub>
-                        </a> <a role="button" href="#" class="pagination-next">
-                            <b-icon-stub type="is-primary is-clickable" icon="chevron-right" both="true"></b-icon-stub>
-                        </a>
-                        <div class="pagination-list">
-                            <b-field-stub addons="true">
-                                <b-select-stub usehtml5validation="true" statusicon="true" value="7">
-                                    <option value="0">
-                                        January
-                                    </option>
-                                    <option value="1">
-                                        February
-                                    </option>
-                                    <option value="2">
-                                        March
-                                    </option>
-                                    <option value="3">
-                                        April
-                                    </option>
-                                    <option value="4">
-                                        May
-                                    </option>
-                                    <option value="5">
-                                        June
-                                    </option>
-                                    <option value="6">
-                                        July
-                                    </option>
-                                    <option value="7">
-                                        August
-                                    </option>
-                                    <option value="8">
-                                        September
-                                    </option>
-                                    <option value="9">
-                                        October
-                                    </option>
-                                    <option value="10">
-                                        November
-                                    </option>
-                                    <option value="11">
-                                        December
-                                    </option>
-                                </b-select-stub>
-                                <b-select-stub usehtml5validation="true" statusicon="true" value="2018">
-                                    <option value="2028">
-                                        2028
-                                    </option>
-                                    <option value="2027">
-                                        2027
-                                    </option>
-                                    <option value="2026">
-                                        2026
-                                    </option>
-                                    <option value="2025">
-                                        2025
-                                    </option>
-                                    <option value="2024">
-                                        2024
-                                    </option>
-                                    <option value="2023">
-                                        2023
-                                    </option>
-                                    <option value="2022">
-                                        2022
-                                    </option>
-                                    <option value="2021">
-                                        2021
-                                    </option>
-                                    <option value="2020">
-                                        2020
-                                    </option>
-                                    <option value="2019">
-                                        2019
-                                    </option>
-                                    <option value="2018">
-                                        2018
-                                    </option>
-                                    <option value="2017">
-                                        2017
-                                    </option>
-                                    <option value="2016">
-                                        2016
-                                    </option>
-                                    <option value="2015">
-                                        2015
-                                    </option>
-                                    <option value="2014">
-                                        2014
-                                    </option>
-                                    <option value="2013">
-                                        2013
-                                    </option>
-                                    <option value="2012">
-                                        2012
-                                    </option>
-                                    <option value="2011">
-                                        2011
-                                    </option>
-                                    <option value="2010">
-                                        2010
-                                    </option>
-                                    <option value="2009">
-                                        2009
-                                    </option>
-                                    <option value="2008">
-                                        2008
-                                    </option>
-                                    <option value="2007">
-                                        2007
-                                    </option>
-                                    <option value="2006">
-                                        2006
-                                    </option>
-                                    <option value="2005">
-                                        2005
-                                    </option>
-                                    <option value="2004">
-                                        2004
-                                    </option>
-                                    <option value="2003">
-                                        2003
-                                    </option>
-                                    <option value="2002">
-                                        2002
-                                    </option>
-                                    <option value="2001">
-                                        2001
-                                    </option>
-                                    <option value="2000">
-                                        2000
-                                    </option>
-                                    <option value="1999">
-                                        1999
-                                    </option>
-                                    <option value="1998">
-                                        1998
-                                    </option>
-                                    <option value="1997">
-                                        1997
-                                    </option>
-                                    <option value="1996">
-                                        1996
-                                    </option>
-                                    <option value="1995">
-                                        1995
-                                    </option>
-                                    <option value="1994">
-                                        1994
-                                    </option>
-                                    <option value="1993">
-                                        1993
-                                    </option>
-                                    <option value="1992">
-                                        1992
-                                    </option>
-                                    <option value="1991">
-                                        1991
-                                    </option>
-                                    <option value="1990">
-                                        1990
-                                    </option>
-                                    <option value="1989">
-                                        1989
-                                    </option>
-                                    <option value="1988">
-                                        1988
-                                    </option>
-                                    <option value="1987">
-                                        1987
-                                    </option>
-                                    <option value="1986">
-                                        1986
-                                    </option>
-                                    <option value="1985">
-                                        1985
-                                    </option>
-                                    <option value="1984">
-                                        1984
-                                    </option>
-                                    <option value="1983">
-                                        1983
-                                    </option>
-                                    <option value="1982">
-                                        1982
-                                    </option>
-                                    <option value="1981">
-                                        1981
-                                    </option>
-                                    <option value="1980">
-                                        1980
-                                    </option>
-                                    <option value="1979">
-                                        1979
-                                    </option>
-                                    <option value="1978">
-                                        1978
-                                    </option>
-                                    <option value="1977">
-                                        1977
-                                    </option>
-                                    <option value="1976">
-                                        1976
-                                    </option>
-                                    <option value="1975">
-                                        1975
-                                    </option>
-                                    <option value="1974">
-                                        1974
-                                    </option>
-                                    <option value="1973">
-                                        1973
-                                    </option>
-                                    <option value="1972">
-                                        1972
-                                    </option>
-                                    <option value="1971">
-                                        1971
-                                    </option>
-                                    <option value="1970">
-                                        1970
-                                    </option>
-                                    <option value="1969">
-                                        1969
-                                    </option>
-                                    <option value="1968">
-                                        1968
-                                    </option>
-                                    <option value="1967">
-                                        1967
-                                    </option>
-                                    <option value="1966">
-                                        1966
-                                    </option>
-                                    <option value="1965">
-                                        1965
-                                    </option>
-                                    <option value="1964">
-                                        1964
-                                    </option>
-                                    <option value="1963">
-                                        1963
-                                    </option>
-                                    <option value="1962">
-                                        1962
-                                    </option>
-                                    <option value="1961">
-                                        1961
-                                    </option>
-                                    <option value="1960">
-                                        1960
-                                    </option>
-                                    <option value="1959">
-                                        1959
-                                    </option>
-                                    <option value="1958">
-                                        1958
-                                    </option>
-                                    <option value="1957">
-                                        1957
-                                    </option>
-                                    <option value="1956">
-                                        1956
-                                    </option>
-                                    <option value="1955">
-                                        1955
-                                    </option>
-                                    <option value="1954">
-                                        1954
-                                    </option>
-                                    <option value="1953">
-                                        1953
-                                    </option>
-                                    <option value="1952">
-                                        1952
-                                    </option>
-                                    <option value="1951">
-                                        1951
-                                    </option>
-                                    <option value="1950">
-                                        1950
-                                    </option>
-                                    <option value="1949">
-                                        1949
-                                    </option>
-                                    <option value="1948">
-                                        1948
-                                    </option>
-                                    <option value="1947">
-                                        1947
-                                    </option>
-                                    <option value="1946">
-                                        1946
-                                    </option>
-                                    <option value="1945">
-                                        1945
-                                    </option>
-                                    <option value="1944">
-                                        1944
-                                    </option>
-                                    <option value="1943">
-                                        1943
-                                    </option>
-                                    <option value="1942">
-                                        1942
-                                    </option>
-                                    <option value="1941">
-                                        1941
-                                    </option>
-                                    <option value="1940">
-                                        1940
-                                    </option>
-                                    <option value="1939">
-                                        1939
-                                    </option>
-                                    <option value="1938">
-                                        1938
-                                    </option>
-                                    <option value="1937">
-                                        1937
-                                    </option>
-                                    <option value="1936">
-                                        1936
-                                    </option>
-                                    <option value="1935">
-                                        1935
-                                    </option>
-                                    <option value="1934">
-                                        1934
-                                    </option>
-                                    <option value="1933">
-                                        1933
-                                    </option>
-                                    <option value="1932">
-                                        1932
-                                    </option>
-                                    <option value="1931">
-                                        1931
-                                    </option>
-                                    <option value="1930">
-                                        1930
-                                    </option>
-                                    <option value="1929">
-                                        1929
-                                    </option>
-                                    <option value="1928">
-                                        1928
-                                    </option>
-                                    <option value="1927">
-                                        1927
-                                    </option>
-                                    <option value="1926">
-                                        1926
-                                    </option>
-                                    <option value="1925">
-                                        1925
-                                    </option>
-                                    <option value="1924">
-                                        1924
-                                    </option>
-                                    <option value="1923">
-                                        1923
-                                    </option>
-                                    <option value="1922">
-                                        1922
-                                    </option>
-                                    <option value="1921">
-                                        1921
-                                    </option>
-                                    <option value="1920">
-                                        1920
-                                    </option>
-                                    <option value="1919">
-                                        1919
-                                    </option>
-                                    <option value="1918">
-                                        1918
-                                    </option>
-                                </b-select-stub>
-                            </b-field-stub>
+              <header class="datepicker-header">
+                <div class="pagination field is-centered"><a class="pagination-previous" role="button" href="#">
+                    <b-icon-stub icon="chevron-left" type="is-primary is-clickable" both="true"></b-icon-stub>
+                  </a><a class="pagination-next" role="button" href="#">
+                    <b-icon-stub icon="chevron-right" type="is-primary is-clickable" both="true"></b-icon-stub>
+                  </a>
+                  <div class="pagination-list">
+                    <div class="field">
+                      <!--v-if-->
+                      <div class="field-body">
+                        <div class="field has-addons">
+                          <!--v-if-->
+                          <div class="control"><span class="select"><select><!--v-if--><option value="0">January</option><option value="1">February</option><option value="2">March</option><option value="3">April</option><option value="4">May</option><option value="5">June</option><option value="6">July</option><option value="7">August</option><option value="8">September</option><option value="9">October</option><option value="10">November</option><option value="11">December</option></select></span>
+                            <!--v-if-->
+                          </div>
+                          <div class="control"><span class="select"><select><!--v-if--><option value="2028">2028</option><option value="2027">2027</option><option value="2026">2026</option><option value="2025">2025</option><option value="2024">2024</option><option value="2023">2023</option><option value="2022">2022</option><option value="2021">2021</option><option value="2020">2020</option><option value="2019">2019</option><option value="2018">2018</option><option value="2017">2017</option><option value="2016">2016</option><option value="2015">2015</option><option value="2014">2014</option><option value="2013">2013</option><option value="2012">2012</option><option value="2011">2011</option><option value="2010">2010</option><option value="2009">2009</option><option value="2008">2008</option><option value="2007">2007</option><option value="2006">2006</option><option value="2005">2005</option><option value="2004">2004</option><option value="2003">2003</option><option value="2002">2002</option><option value="2001">2001</option><option value="2000">2000</option><option value="1999">1999</option><option value="1998">1998</option><option value="1997">1997</option><option value="1996">1996</option><option value="1995">1995</option><option value="1994">1994</option><option value="1993">1993</option><option value="1992">1992</option><option value="1991">1991</option><option value="1990">1990</option><option value="1989">1989</option><option value="1988">1988</option><option value="1987">1987</option><option value="1986">1986</option><option value="1985">1985</option><option value="1984">1984</option><option value="1983">1983</option><option value="1982">1982</option><option value="1981">1981</option><option value="1980">1980</option><option value="1979">1979</option><option value="1978">1978</option><option value="1977">1977</option><option value="1976">1976</option><option value="1975">1975</option><option value="1974">1974</option><option value="1973">1973</option><option value="1972">1972</option><option value="1971">1971</option><option value="1970">1970</option><option value="1969">1969</option><option value="1968">1968</option><option value="1967">1967</option><option value="1966">1966</option><option value="1965">1965</option><option value="1964">1964</option><option value="1963">1963</option><option value="1962">1962</option><option value="1961">1961</option><option value="1960">1960</option><option value="1959">1959</option><option value="1958">1958</option><option value="1957">1957</option><option value="1956">1956</option><option value="1955">1955</option><option value="1954">1954</option><option value="1953">1953</option><option value="1952">1952</option><option value="1951">1951</option><option value="1950">1950</option><option value="1949">1949</option><option value="1948">1948</option><option value="1947">1947</option><option value="1946">1946</option><option value="1945">1945</option><option value="1944">1944</option><option value="1943">1943</option><option value="1942">1942</option><option value="1941">1941</option><option value="1940">1940</option><option value="1939">1939</option><option value="1938">1938</option><option value="1937">1937</option><option value="1936">1936</option><option value="1935">1935</option><option value="1934">1934</option><option value="1933">1933</option><option value="1932">1932</option><option value="1931">1931</option><option value="1930">1930</option><option value="1929">1929</option><option value="1928">1928</option><option value="1927">1927</option><option value="1926">1926</option><option value="1925">1925</option><option value="1924">1924</option><option value="1923">1923</option><option value="1922">1922</option><option value="1921">1921</option><option value="1920">1920</option><option value="1919">1919</option><option value="1918">1918</option></select></span>
+                            <!--v-if-->
+                          </div>
+                          <!--v-if-->
                         </div>
+                      </div>
+                      <!--v-if-->
                     </div>
-                </header>
-                <div class="datepicker-content">
-                    <b-datepicker-table-stub daynames="Su,M,Tu,W,Th,F,S" monthnames="January,February,March,April,May,June,July,August,September,October,November,December" firstdayofweek="0" indicators="dots" focused="[object Object]" datecreator="function dateCreator() {}" nearbymonthdays="true" rulesforfirstweek="4"></b-datepicker-table-stub>
+                  </div>
                 </div>
+              </header>
+              <div class="datepicker-content">
+                <b-datepicker-table-stub daynames="Su,M,Tu,W,Th,F,S" monthnames="January,February,March,April,May,June,July,August,September,October,November,December" firstdayofweek="0" rulesforfirstweek="4" focused="[object Object]" indicators="dots" datecreator="[Function]" nearbymonthdays="true" nearbyselectablemonthdays="false" showweeknumber="false" weeknumberclickable="false" range="false" multiple="false" type-month="false"></b-datepicker-table-stub>
+              </div>
             </div>
-            <!---->
-        </b-dropdown-item-stub>
-    </b-dropdown-stub>
+            <!--v-if-->
+          </div>
+        </div>
+      </div>
+    </transition-stub>
+  </div>
 </div>
 `;

--- a/src/components/datepicker/__snapshots__/DatepickerMonth.spec.js.snap
+++ b/src/components/datepicker/__snapshots__/DatepickerMonth.spec.js.snap
@@ -2,32 +2,32 @@
 
 exports[`BDatepickerMonth render correctly 1`] = `
 <section class="datepicker-table">
-    <div class="datepicker-body">
-        <div class="datepicker-months"><a role="button" href="#" tabindex="-1" class="datepicker-cell is-selectable">
-                January
-                <!----></a><a role="button" href="#" tabindex="-1" class="datepicker-cell is-selectable">
-                February
-                <!----></a><a role="button" href="#" tabindex="-1" class="datepicker-cell is-selectable">
-                March
-                <!----></a><a role="button" href="#" tabindex="-1" class="datepicker-cell is-selectable">
-                April
-                <!----></a><a role="button" href="#" class="datepicker-cell is-selectable">
-                May
-                <!----></a><a role="button" href="#" tabindex="-1" class="datepicker-cell is-selectable">
-                June
-                <!----></a><a role="button" href="#" tabindex="-1" class="datepicker-cell is-selectable">
-                July
-                <!----></a><a role="button" href="#" tabindex="-1" class="datepicker-cell is-selectable">
-                August
-                <!----></a><a role="button" href="#" tabindex="-1" class="datepicker-cell is-selectable">
-                September
-                <!----></a><a role="button" href="#" tabindex="-1" class="datepicker-cell is-selectable">
-                October
-                <!----></a><a role="button" href="#" tabindex="-1" class="datepicker-cell is-selectable">
-                November
-                <!----></a><a role="button" href="#" tabindex="-1" class="datepicker-cell is-selectable">
-                December
-                <!----></a></div>
-    </div>
+  <div class="datepicker-body">
+    <div class="datepicker-months"><a class="is-selectable datepicker-cell" role="button" href="#" tabindex="-1">January
+        <!--v-if-->
+      </a><a class="is-selectable datepicker-cell" role="button" href="#" tabindex="-1">February
+        <!--v-if-->
+      </a><a class="is-selectable datepicker-cell" role="button" href="#" tabindex="-1">March
+        <!--v-if-->
+      </a><a class="is-selectable datepicker-cell" role="button" href="#" tabindex="-1">April
+        <!--v-if-->
+      </a><a class="is-selectable datepicker-cell" role="button" href="#">May
+        <!--v-if-->
+      </a><a class="is-selectable datepicker-cell" role="button" href="#" tabindex="-1">June
+        <!--v-if-->
+      </a><a class="is-selectable datepicker-cell" role="button" href="#" tabindex="-1">July
+        <!--v-if-->
+      </a><a class="is-selectable datepicker-cell" role="button" href="#" tabindex="-1">August
+        <!--v-if-->
+      </a><a class="is-selectable datepicker-cell" role="button" href="#" tabindex="-1">September
+        <!--v-if-->
+      </a><a class="is-selectable datepicker-cell" role="button" href="#" tabindex="-1">October
+        <!--v-if-->
+      </a><a class="is-selectable datepicker-cell" role="button" href="#" tabindex="-1">November
+        <!--v-if-->
+      </a><a class="is-selectable datepicker-cell" role="button" href="#" tabindex="-1">December
+        <!--v-if-->
+      </a></div>
+  </div>
 </section>
 `;

--- a/src/components/datepicker/__snapshots__/DatepickerTable.spec.js.snap
+++ b/src/components/datepicker/__snapshots__/DatepickerTable.spec.js.snap
@@ -2,15 +2,15 @@
 
 exports[`BDatepickerTable render correctly 1`] = `
 <section class="datepicker-table">
-    <header class="datepicker-header">
-        <div class="datepicker-cell"><span>Su</span></div>
-        <div class="datepicker-cell"><span>M</span></div>
-        <div class="datepicker-cell"><span>Tu</span></div>
-        <div class="datepicker-cell"><span>W</span></div>
-        <div class="datepicker-cell"><span>Th</span></div>
-        <div class="datepicker-cell"><span>F</span></div>
-        <div class="datepicker-cell"><span>S</span></div>
-    </header>
-    <div class="datepicker-body"></div>
+  <header class="datepicker-header">
+    <div class="datepicker-cell"><span>Su</span></div>
+    <div class="datepicker-cell"><span>M</span></div>
+    <div class="datepicker-cell"><span>Tu</span></div>
+    <div class="datepicker-cell"><span>W</span></div>
+    <div class="datepicker-cell"><span>Th</span></div>
+    <div class="datepicker-cell"><span>F</span></div>
+    <div class="datepicker-cell"><span>S</span></div>
+  </header>
+  <div class="datepicker-body"></div>
 </section>
 `;

--- a/src/components/datepicker/__snapshots__/DatepickerTableRow.spec.js.snap
+++ b/src/components/datepicker/__snapshots__/DatepickerTableRow.spec.js.snap
@@ -2,12 +2,20 @@
 
 exports[`BDatepickerTableRow render correctly 1`] = `
 <div class="datepicker-row">
-    <!----> <a role="button" href="#" tabindex="-1" class="datepicker-cell is-selectable is-invisible"><span>31</span>
-        <!----></a><a role="button" href="#" tabindex="-1" class="datepicker-cell is-selectable is-invisible"><span>1</span>
-        <!----></a><a role="button" href="#" tabindex="-1" class="datepicker-cell is-selectable is-invisible"><span>2</span>
-        <!----></a><a role="button" href="#" tabindex="-1" class="datepicker-cell is-selectable is-invisible"><span>3</span>
-        <!----></a><a role="button" href="#" tabindex="-1" class="datepicker-cell is-selectable is-invisible"><span>4</span>
-        <!----></a><a role="button" href="#" tabindex="-1" class="datepicker-cell is-selectable is-invisible"><span>5</span>
-        <!----></a><a role="button" href="#" tabindex="-1" class="datepicker-cell is-selectable is-invisible"><span>6</span>
-        <!----></a></div>
+  <!--v-if--><a class="is-selectable is-invisible datepicker-cell" role="button" href="#" tabindex="-1"><span>31</span>
+    <!--v-if-->
+  </a><a class="is-selectable is-invisible datepicker-cell" role="button" href="#" tabindex="-1"><span>1</span>
+    <!--v-if-->
+  </a><a class="is-selectable is-invisible datepicker-cell" role="button" href="#" tabindex="-1"><span>2</span>
+    <!--v-if-->
+  </a><a class="is-selectable is-invisible datepicker-cell" role="button" href="#" tabindex="-1"><span>3</span>
+    <!--v-if-->
+  </a><a class="is-selectable is-invisible datepicker-cell" role="button" href="#" tabindex="-1"><span>4</span>
+    <!--v-if-->
+  </a><a class="is-selectable is-invisible datepicker-cell" role="button" href="#" tabindex="-1"><span>5</span>
+    <!--v-if-->
+  </a><a class="is-selectable is-invisible datepicker-cell" role="button" href="#" tabindex="-1"><span>6</span>
+    <!--v-if-->
+  </a>
+</div>
 `;


### PR DESCRIPTION
Part of the series of PRs to port unit tests.

The following command should pass:
```sh
npx jest src/components/datepicker
```

You will the following warning while running tests, but it is fine because it happens only in the test environment:
> [Vue warn]: Component emitted event "week-number-click" but it is neither declared in the emits option nor as an "onWeek-number-click" prop.

Related to:
- #1

## Proposed Changes

- Port spec for Datepicker
- Port spec for DatepickerMonth
- Port spec for DatepickerTable
- Port spec for DatepickerTableRow
- Fix a minor issue on DatepickerTableRow
