### PR TITLE
Port spec for Datetimepicker

### DIFF
--- a/src/components/datetimepicker/Datetimepicker.spec.js
+++ b/src/components/datetimepicker/Datetimepicker.spec.js
@@ -6,21 +6,20 @@ let wrapper
 describe('Datetimepicker', () => {
     beforeEach(() => {
         wrapper = shallowMount(Datetimepicker, {
-            propsData: {
+            props: {
                 locale: 'en-US'
             }
         })
     })
 
     it('is called', () => {
-        expect(wrapper.name()).toBe('BDatetimepicker')
-        expect(wrapper.isVueInstance()).toBeTruthy()
+        expect(wrapper.vm).toBeTruthy()
+        expect(wrapper.vm.$options.name).toBe('BDatetimepicker')
     })
 
     it('react accordingly when setting a new value', async () => {
         const date = new Date()
-        wrapper.setProps({ value: date })
-        await wrapper.vm.$nextTick()
+        await wrapper.setProps({ modelValue: date })
 
         expect(wrapper.vm.newValue).toEqual(date)
     })
@@ -28,58 +27,56 @@ describe('Datetimepicker', () => {
     it('react accordingly when setting computedValue', async () => {
         const date = new Date()
         wrapper.vm.computedValue = date
-        const valueEmitted = wrapper.emitted()['input'][0]
+        const valueEmitted = wrapper.emitted()['update:modelValue'][0]
         expect(valueEmitted).toContainEqual(date)
     })
 
     it('react accordingly when handling native picker', () => {
         const date = new Date(2020, 0, 1, 12, 30, 0)
         wrapper.vm.onChangeNativePicker({ target: { value: '2020-01-01T12:30' } })
-        expect(wrapper.emitted()['input']).toEqual([[date]])
+        expect(wrapper.emitted()['update:modelValue']).toEqual([[date]])
     })
 
     it('react accordingly when handling native picker clear', () => {
         wrapper.vm.onChangeNativePicker({ target: { value: '' } })
-        expect(wrapper.emitted()['input']).toEqual([[null]])
+        expect(wrapper.emitted()['update:modelValue']).toEqual([[null]])
     })
 
-    it('react accordingly when setting minDateTime prop and computedValue', () => {
+    it('react accordingly when setting minDateTime prop and computedValue', async () => {
         const min = new Date(2019, 9, 20, 8, 0, 0, 0)
         const date = new Date(2019, 9, 18, 0, 0, 0, 0)
-        wrapper.setProps({
+        await wrapper.setProps({
             minDatetime: min
         })
         wrapper.vm.computedValue = date
-        const valueEmitted = wrapper.emitted()['input'][0]
+        const valueEmitted = wrapper.emitted()['update:modelValue'][0]
         expect(valueEmitted).toContainEqual(min)
     })
 
-    it('react accordingly when setting maxDateTime prop and computedValue', () => {
+    it('react accordingly when setting maxDateTime prop and computedValue', async () => {
         const max = new Date(2019, 9, 18, 0, 0, 0, 0)
         const date = new Date(2019, 9, 20, 8, 0, 0, 0)
-        wrapper.setProps({
+        await wrapper.setProps({
             maxDatetime: max
         })
         wrapper.vm.computedValue = date
-        const valueEmitted = wrapper.emitted()['input'][0]
+        const valueEmitted = wrapper.emitted()['update:modelValue'][0]
         expect(valueEmitted).toContainEqual(max)
     })
 
-    it('should format date time', () => {
+    it('should format date time', async () => {
         const datetimeToFormat = new Date(2019, 9, 1, 8, 30, 0, 0)
         wrapper = mount(Datetimepicker, {
-            propsData: {
-                value: datetimeToFormat
-            },
-            stubs: {
-                transition: false
+            props: {
+                locale: 'en-US',
+                modelValue: datetimeToFormat
             }
         })
-        const datepicker = wrapper.find({ ref: 'datepicker' })
+        const datepicker = wrapper.findComponent({ ref: 'datepicker' })
 
-        expect(datepicker.vm.formattedValue).toEqual('2019-10-1 08:30')
+        expect(datepicker.vm.formattedValue).toEqual('10/1/2019, 8:30 AM')
 
-        wrapper.setProps({
+        await wrapper.setProps({
             datetimeFormatter: (date) => `${date.getFullYear()}`
         })
         expect(datepicker.vm.formattedValue).toEqual('2019')
@@ -87,49 +84,44 @@ describe('Datetimepicker', () => {
 
     it('should format date time with seconds', () => {
         wrapper = mount(Datetimepicker, {
-            propsData: {
+            props: {
+                locale: 'en-US',
                 timepicker: {
                     enableSeconds: true
                 }
-            },
-            stubs: {
-                transition: false
             }
         })
         const datetimeToFormat = new Date(2019, 9, 1, 8, 30, 0, 0)
         const formattedDatetime = wrapper.vm.defaultDatetimeFormatter(datetimeToFormat)
-        expect(formattedDatetime).toEqual('2019-10-1 08:30:00')
+        expect(formattedDatetime).toEqual('10/1/2019, 8:30:00 AM')
     })
 
     it('should format date time according init value', async () => {
         const date = new Date(2019, 9, 1, 8, 30, 0, 0)
         wrapper = mount(Datetimepicker, {
-            propsData: {
-                value: date
-            },
-            stubs: {
-                transition: false
-            },
-            sync: false
+            props: {
+                locale: 'en-US',
+                modelValue: date
+            }
         })
         await wrapper.vm.$nextTick()
-        expect(wrapper.find('input').element.value).toEqual('2019-10-1 08:30')
+        expect(wrapper.find('input').element.value).toEqual('10/1/2019, 8:30 AM')
     })
 
     it('should parse date time', async () => {
         wrapper = mount(Datetimepicker, {
-            stubs: {
-                transition: false
+            props: {
+                locale: 'en-US'
             }
         })
-        const datepicker = wrapper.find({ ref: 'datepicker' })
+        const datepicker = wrapper.findComponent({ ref: 'datepicker' })
 
         let expectedDatetime = new Date(2019, 9, 1, 9, 30, 0, 0)
         datepicker.vm.onChange('2019-10-1 09:30')
         expect(wrapper.vm.computedValue).toEqual(expectedDatetime)
 
         expectedDatetime = new Date(2019, 9, 1, 9, 30, 0, 0)
-        wrapper.setProps({
+        await wrapper.setProps({
             datetimeParser: () => expectedDatetime
         })
         datepicker.vm.onChange('Whatever!')


### PR DESCRIPTION
Part of the series of PRs to port unit tests.

The following command should pass:
```sh
npx jest src/components/datetimepicker
```

You will see the following warning while running the tests. This is due to the issue #23 but should not matter to the test results.
> [Vue warn]: Failed to resolve component: b-input

Related to:
- #1

## Proposed Changes

- Port spec for Datetimepicker