### PR TITLE
Port spec for Message

### DIFF
--- a/src/components/message/Message.spec.js
+++ b/src/components/message/Message.spec.js
@@ -9,8 +9,8 @@ describe('BMessage', () => {
     })
 
     it('is called', () => {
-        expect(wrapper.name()).toBe('BMessage')
-        expect(wrapper.isVueInstance()).toBeTruthy()
+        expect(wrapper.vm).toBeTruthy()
+        expect(wrapper.vm.$options.name).toBe('BMessage')
     })
 
     it('render correctly', () => {

--- a/src/components/message/__snapshots__/Message.spec.js.snap
+++ b/src/components/message/__snapshots__/Message.spec.js.snap
@@ -1,9 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BMessage render correctly 1`] = `
-<article class="message" name="fade">
-    <!---->
-    <!---->
-    <!---->
-</article>
+<transition-stub name="fade" appear="false" persisted="true" css="true">
+  <article class="message">
+    <!--v-if-->
+    <!--v-if-->
+    <!--v-if-->
+  </article>
+</transition-stub>
 `;

--- a/src/utils/MessageMixin.spec.js
+++ b/src/utils/MessageMixin.spec.js
@@ -7,11 +7,11 @@ describe('MessageMixin', () => {
     HTMLElement.prototype.insertAdjacentElement = jest.fn()
     beforeEach(() => {
         const component = {
-            template: '<div class="b-component"></div>'
+            template: '<div class="b-component"></div>',
+            mixins: [MessageMixin]
         }
         wrapper = shallowMount(component, {
-            attachToDocument: true,
-            mixins: [MessageMixin]
+            attachTo: document.body
         })
     })
 
@@ -19,34 +19,29 @@ describe('MessageMixin', () => {
         expect(wrapper.vm.isActive).toBeTruthy()
     })
 
-    it('should set isActive when active is set', (done) => {
-        wrapper.setProps({active: false})
-        wrapper.vm.$nextTick(() => {
-            expect(wrapper.vm.isActive).toBeFalsy()
-            done()
-        })
+    it('should set isActive when active is set', async () => {
+        await wrapper.setProps({ modelValue: false })
+        expect(wrapper.vm.isActive).toBeFalsy()
     })
 
-    it('should return correct icon depending on type', () => {
+    it('should return correct icon depending on type', async () => {
         const expected = {
             'is-info': 'information',
             'is-success': 'check-circle',
             'is-warning': 'alert',
             'is-danger': 'alert-circle',
-            'other': null
+            other: null
         }
-        for (let [key, value] of Object.entries(expected)) {
-            wrapper.setProps({type: key})
+        for (const [key, value] of Object.entries(expected)) {
+            await wrapper.setProps({ type: key })
             expect(wrapper.vm.computedIcon).toEqual(value)
         }
     })
 
-    it('should reset isActive and emit close event on close', (done) => {
+    it('should reset isActive and emit close event on close', async () => {
         wrapper.vm.close()
-        wrapper.vm.$nextTick(() => {
-            expect(wrapper.vm.isActive).toBeFalsy()
-            expect(wrapper.emitted()['close']).toBeTruthy()
-            done()
-        })
+        await wrapper.vm.$nextTick()
+        expect(wrapper.vm.isActive).toBeFalsy()
+        expect(wrapper.emitted().close).toBeTruthy()
     })
 })


### PR DESCRIPTION
Part of the series of PRs to port unit tests.

The following command should pass:
```sh
npx jest test src/utils/MessageMixin.spec.js src/components/message
```

You will see the following warning while running the tests. This is due to the issue #24 but should not matter to the test results:
> [Vue warn]: Failed to resolve component: b-progress

Related to:
- #1

## Proposed Changes

- Port MessageMixin
- Port Message