### PR TITLE
Port spec for Notification

### DIFF
--- a/src/components/notification/Notification.spec.js
+++ b/src/components/notification/Notification.spec.js
@@ -9,8 +9,8 @@ describe('BNotification', () => {
     })
 
     it('is called', () => {
-        expect(wrapper.name()).toBe('BNotification')
-        expect(wrapper.isVueInstance()).toBeTruthy()
+        expect(wrapper.vm).toBeTruthy()
+        expect(wrapper.vm.$options.name).toBe('BNotification')
     })
 
     it('render correctly', () => {

--- a/src/components/notification/__snapshots__/Notification.spec.js.snap
+++ b/src/components/notification/__snapshots__/Notification.spec.js.snap
@@ -1,8 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BNotification render correctly 1`] = `
-<article class="notification" name="fade"><button type="button" class="delete"></button>
-    <!---->
-    <!---->
-</article>
+<transition-stub name="fade" appear="false" persisted="true" css="true">
+  <article class="notification"><button class="delete" type="button"></button>
+    <!--v-if-->
+    <!--v-if-->
+  </article>
+</transition-stub>
 `;


### PR DESCRIPTION
Part of the series of PRs to port unit tests.

The following command should pass:
```sh
npx jest src/components/notification
```

Related to:
- #1

## Proposed Changes

- Port spec for Notification