### PR TITLE
Port spec for Progress

### DIFF
--- a/src/components/progress/Progress.spec.js
+++ b/src/components/progress/Progress.spec.js
@@ -4,8 +4,8 @@ import BProgress from '@components/progress/Progress'
 describe('BProgress', () => {
     it('is called', () => {
         const wrapper = shallowMount(BProgress)
-        expect(wrapper.name()).toBe('BProgress')
-        expect(wrapper.isVueInstance()).toBeTruthy()
+        expect(wrapper.vm).toBeTruthy()
+        expect(wrapper.vm.$options.name).toBe('BProgress')
     })
 
     it('render correctly', () => {
@@ -17,9 +17,8 @@ describe('BProgress', () => {
     it('add value attribute when a value is passed', async () => {
         const value = 50
         const wrapper = shallowMount(BProgress)
-        wrapper.setProps({ value })
+        await wrapper.setProps({ value })
 
-        await wrapper.vm.$nextTick()
         expect(wrapper.find('.progress').attributes().value).toEqual(`${value}`)
     })
 
@@ -27,7 +26,7 @@ describe('BProgress', () => {
         it('remove value attribute to the <progress> element', async () => {
             const value = null
             const wrapper = shallowMount(BProgress, {
-                propsData: {value}
+                props: { value }
             })
 
             await wrapper.vm.$nextTick()
@@ -38,7 +37,7 @@ describe('BProgress', () => {
             it('adds a help <p> element in the root div.progress-wrapper when "show-value" prop is true', () => {
                 const value = 50
                 const wrapper = shallowMount(BProgress, {
-                    propsData: {
+                    props: {
                         value,
                         showValue: true
                     }
@@ -51,7 +50,7 @@ describe('BProgress', () => {
                 const max = 100
                 const format = 'percent'
                 const wrapper = shallowMount(BProgress, {
-                    propsData: {
+                    props: {
                         value,
                         max,
                         format,
@@ -68,7 +67,7 @@ describe('BProgress', () => {
                 const value = 50
                 const keepTrailingZeroes = true
                 const wrapper = shallowMount(BProgress, {
-                    propsData: {
+                    props: {
                         value,
                         keepTrailingZeroes,
                         showValue: true

--- a/src/components/progress/ProgressBar.spec.js
+++ b/src/components/progress/ProgressBar.spec.js
@@ -1,23 +1,25 @@
-import { shallowMount } from '@vue/test-utils'
+import { mount } from '@vue/test-utils'
 import BProgressBar from '@components/progress/ProgressBar'
 import ProviderParentMixin from '../../utils/ProviderParentMixin'
 
 let wrapper
 const BProgress = {
     mixins: [ProviderParentMixin('progress')],
-    template: '<b-progress-stub></b-progress-stub>'
+    template: '<div><slot /></div>'
 }
 
 describe('BProgressBar', () => {
     beforeEach(() => {
-        wrapper = shallowMount(BProgressBar, {
-            parentComponent: BProgress
-        })
+        wrapper = mount(BProgress, {
+            slots: {
+                default: BProgressBar
+            }
+        }).findComponent(BProgressBar)
     })
 
     it('is called', () => {
-        expect(wrapper.name()).toBe('BProgressBar')
-        expect(wrapper.isVueInstance()).toBeTruthy()
+        expect(wrapper.vm).toBeTruthy()
+        expect(wrapper.vm.$options.name).toBe('BProgressBar')
     })
 
     it('render correctly', () => {

--- a/src/components/progress/__snapshots__/Progress.spec.js.snap
+++ b/src/components/progress/__snapshots__/Progress.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BProgress render correctly 1`] = `
-<div class="progress-wrapper"><progress max="100" class="progress is-darkgrey"></progress>
-    <!---->
+<div class="progress-wrapper"><progress class="progress is-darkgrey" max="100"></progress>
+  <!--v-if-->
 </div>
 `;

--- a/src/components/progress/__snapshots__/ProgressBar.spec.js.snap
+++ b/src/components/progress/__snapshots__/ProgressBar.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BProgressBar render correctly 1`] = `
-<div role="progressbar" aria-valuemin="0" class="progress-bar">
-    <!---->
+<div class="progress-bar" role="progressbar" aria-valuemin="0">
+  <!--v-if-->
 </div>
 `;


### PR DESCRIPTION
Part of the series of PRs to port unit tests.

The following command should pass:
```sh
npx jest src/components/progress
```

Related issue:
- #1

## Proposed Changes

- Port spec for Progress
- Port spec for ProgressBar