### PR TITLE
Port spec for Breadcrumb

### DIFF
--- a/src/components/breadcrumb/Breadcrumb.spec.js
+++ b/src/components/breadcrumb/Breadcrumb.spec.js
@@ -9,8 +9,8 @@ describe('BBreadcrumb', () => {
     })
 
     it('is called', () => {
-        expect(wrapper.name()).toBe('BBreadcrumb')
-        expect(wrapper.isVueInstance()).toBeTruthy()
+        expect(wrapper.vm).toBeTruthy()
+        expect(wrapper.vm.$options.name).toBe('BBreadcrumb')
     })
 
     it('render correctly', () => {
@@ -19,7 +19,7 @@ describe('BBreadcrumb', () => {
 
     it('should set align to right', () => {
         wrapper = mount(BBreadcrumb, {
-            propsData: {
+            props: {
                 align: 'is-right'
             }
         })
@@ -29,7 +29,7 @@ describe('BBreadcrumb', () => {
 
     it('should set separator to arrow', () => {
         wrapper = mount(BBreadcrumb, {
-            propsData: {
+            props: {
                 separator: 'has-arrow-separator'
             }
         })
@@ -39,7 +39,7 @@ describe('BBreadcrumb', () => {
 
     it('should set size to large', () => {
         wrapper = mount(BBreadcrumb, {
-            propsData: {
+            props: {
                 size: 'is-large'
             }
         })
@@ -49,7 +49,7 @@ describe('BBreadcrumb', () => {
 
     it('computes breadcrumbClasses correctly', () => {
         wrapper = mount(BBreadcrumb, {
-            propsData: {
+            props: {
                 align: 'is-left',
                 separator: 'has-dot-separator',
                 size: 'is-medium'

--- a/src/components/breadcrumb/BreadcrumbItem.spec.js
+++ b/src/components/breadcrumb/BreadcrumbItem.spec.js
@@ -5,14 +5,14 @@ describe('BBreadcrumbItem', () => {
     let wrapper
     beforeEach(() => {
         wrapper = mount(BBreadcrumbItem, {
-            propsData: {
+            props: {
                 tag: 'a'
             }
         })
     })
 
     it('is called', () => {
-        expect(wrapper.isVueInstance()).toBeTruthy()
+        expect(wrapper.vm).toBeTruthy()
     })
 
     it('render correctly', () => {
@@ -20,6 +20,6 @@ describe('BBreadcrumbItem', () => {
     })
 
     it('should have a li tag', () => {
-        expect(wrapper.contains('li')).toBeTruthy()
+        expect(wrapper.find('li').exists()).toBeTruthy()
     })
 })

--- a/src/components/breadcrumb/__snapshots__/Breadcrumb.spec.js.snap
+++ b/src/components/breadcrumb/__snapshots__/Breadcrumb.spec.js.snap
@@ -2,6 +2,6 @@
 
 exports[`BBreadcrumb render correctly 1`] = `
 <nav class="breadcrumb is-left is-medium">
-    <ul></ul>
+  <ul></ul>
 </nav>
 `;


### PR DESCRIPTION
Part of the series of PRs to port unit tests.

The following command should pass:
```sh
npx jest src/components/breadcrumb
```

Related to:
- #1

## Proposed Changes

- Port spec for Breadcrumb
- Port spec for BreadcrumbItem