### PR TITLE
Port spec for Colorpicker

### DIFF
--- a/src/components/colorpicker/Colorpicker.spec.js
+++ b/src/components/colorpicker/Colorpicker.spec.js
@@ -3,7 +3,17 @@ import BColorpicker from '@components/colorpicker/Colorpicker'
 
 describe('BColorpicker', () => {
     it('render correctly', () => {
-        const wrapper = shallowMount(BColorpicker)
+        const wrapper = shallowMount(BColorpicker, {
+            global: {
+                stubs: {
+                    // to better reproduce the legacy snapshot
+                    'b-dropdown': false,
+                    'b-dropdown-item': false,
+                    'b-field': false,
+                    'b-field-body': false
+                }
+            }
+        })
 
         expect(wrapper.html()).toMatchSnapshot()
     })

--- a/src/components/colorpicker/ColorpickerAlphaSlider.spec.js
+++ b/src/components/colorpicker/ColorpickerAlphaSlider.spec.js
@@ -5,7 +5,7 @@ import BColorpickerAlphaSlider from '@components/colorpicker/ColorpickerAlphaSli
 describe('BColorpickerAlphaSlider', () => {
     it('render correctly', () => {
         const wrapper = shallowMount(BColorpickerAlphaSlider, {
-            propsData: {
+            props: {
                 value: 100,
                 color: Color.parse('#123456')
             }

--- a/src/components/colorpicker/ColorpickerHSLRepresentationSquare.spec.js
+++ b/src/components/colorpicker/ColorpickerHSLRepresentationSquare.spec.js
@@ -12,7 +12,7 @@ describe('BColorpickerHSLRepresentationSquare', () => {
     })
     it('render correctly', () => {
         const wrapper = shallowMount(BColorpickerHSLRepresentationSquare, {
-            propsData: {
+            props: {
                 ...defaultProps()
             }
         })

--- a/src/components/colorpicker/ColorpickerHSLRepresentationTriangle.spec.js
+++ b/src/components/colorpicker/ColorpickerHSLRepresentationTriangle.spec.js
@@ -12,7 +12,7 @@ describe('BColorpickerHSLRepresentationTriangle', () => {
     })
     it('render correctly', () => {
         const wrapper = shallowMount(BColorpickerHSLRepresentationTriangle, {
-            propsData: {
+            props: {
                 ...defaultProps()
             }
         })

--- a/src/components/colorpicker/__snapshots__/Colorpicker.spec.js.snap
+++ b/src/components/colorpicker/__snapshots__/Colorpicker.spec.js.snap
@@ -2,31 +2,75 @@
 
 exports[`BColorpicker render correctly 1`] = `
 <div class="colorpicker control">
-    <b-dropdown-stub maxheight="200" triggers="click" mobilemodal="true" ariarole="dialog" animation="fade" trapfocus="true" closeonclick="true" canclose="true" appendtobodycopyparent="true" aria-modal="true">
-        <b-dropdown-item-stub custom="true" focusable="true" ariarole="" class="">
+  <div class="dropdown dropdown-menu-animation is-mobile-modal">
+    <div tabindex="0" class="dropdown-trigger" aria-haspopup="true">
+      <b-button style="background-color: rgb(255, 255, 255); background-size: 100% 100%, 16px 16px, 16px 16px; color: rgb(255, 255, 255); text-shadow: 0 0 2px #000000AA;" expanded="false" disabled="false"><span class="color-name">#00000000</span></b-button>
+    </div>
+    <transition-stub name="fade" appear="false" persisted="false" css="true">
+      <div class="background" aria-hidden="true" style="display: none;"></div>
+    </transition-stub>
+    <transition-stub name="fade" appear="false" persisted="true" css="true">
+      <div class="dropdown-menu" aria-hidden="true" style="display: none;">
+        <div class="dropdown-content" role="dialog" aria-modal="true">
+          <div class="dropdown-item" tabindex="0">
             <div>
-                <header class="colorpicker-header">
-                    <!---->
-                </header>
-                <div class="colorpicker-content">
-                    <b-colorpicker-h-s-l-representation-triangle-stub value="#000000" size="200" thickness="20"></b-colorpicker-h-s-l-representation-triangle-stub>
-                </div>
+              <header class="colorpicker-header">
+                <!--v-if-->
+              </header>
+              <div class="colorpicker-content">
+                <b-colorpicker-h-s-l-representation-triangle-stub size="200" thickness="20" value="#000000"></b-colorpicker-h-s-l-representation-triangle-stub>
+              </div>
             </div>
             <footer class="colorpicker-footer">
-                <!---->
-                <b-field-stub grouped="true" addons="true" class="colorpicker-fields">
-                    <b-field-stub label="R" horizontal="true" addons="true">
-                        <b-input-stub size="is-small" usehtml5validation="true" statusicon="true" value="0" type="number" hascounter="true" customclass="" aria-label="Red"></b-input-stub>
-                    </b-field-stub>
-                    <b-field-stub label="G" horizontal="true" addons="true">
-                        <b-input-stub size="is-small" usehtml5validation="true" statusicon="true" value="0" type="number" hascounter="true" customclass="" aria-label="Green"></b-input-stub>
-                    </b-field-stub>
-                    <b-field-stub label="B" horizontal="true" addons="true">
-                        <b-input-stub size="is-small" usehtml5validation="true" statusicon="true" value="0" type="number" hascounter="true" customclass="" aria-label="Blue"></b-input-stub>
-                    </b-field-stub>
-                </b-field-stub>
+              <!--v-if-->
+              <div class="field colorpicker-fields">
+                <!--v-if-->
+                <div class="field-body">
+                  <div class="field is-grouped">
+                    <!--v-if-->
+                    <div class="field is-horizontal">
+                      <div class="field-label"><label class="label">R</label></div>
+                      <div class="field-body">
+                        <div class="field">
+                          <!--v-if-->
+                          <b-input-stub modelvalue="0" type="number" lazy="false" passwordreveal="false" iconclickable="false" hascounter="true" customclass="" iconrightclickable="false" modelmodifiers="[object Object]" size="is-small" aria-label="Red"></b-input-stub>
+                          <!--v-if-->
+                        </div>
+                      </div>
+                      <!--v-if-->
+                    </div>
+                    <div class="field is-horizontal">
+                      <div class="field-label"><label class="label">G</label></div>
+                      <div class="field-body">
+                        <div class="field">
+                          <!--v-if-->
+                          <b-input-stub modelvalue="0" type="number" lazy="false" passwordreveal="false" iconclickable="false" hascounter="true" customclass="" iconrightclickable="false" modelmodifiers="[object Object]" size="is-small" aria-label="Green"></b-input-stub>
+                          <!--v-if-->
+                        </div>
+                      </div>
+                      <!--v-if-->
+                    </div>
+                    <div class="field is-horizontal">
+                      <div class="field-label"><label class="label">B</label></div>
+                      <div class="field-body">
+                        <div class="field">
+                          <!--v-if-->
+                          <b-input-stub modelvalue="0" type="number" lazy="false" passwordreveal="false" iconclickable="false" hascounter="true" customclass="" iconrightclickable="false" modelmodifiers="[object Object]" size="is-small" aria-label="Blue"></b-input-stub>
+                          <!--v-if-->
+                        </div>
+                      </div>
+                      <!--v-if-->
+                    </div>
+                    <!--v-if-->
+                  </div>
+                </div>
+                <!--v-if-->
+              </div>
             </footer>
-        </b-dropdown-item-stub>
-    </b-dropdown-stub>
+          </div>
+        </div>
+      </div>
+    </transition-stub>
+  </div>
 </div>
 `;

--- a/src/components/colorpicker/__snapshots__/ColorpickerAlphaSlider.spec.js.snap
+++ b/src/components/colorpicker/__snapshots__/ColorpickerAlphaSlider.spec.js.snap
@@ -2,10 +2,8 @@
 
 exports[`BColorpickerAlphaSlider render correctly 1`] = `
 <div class="b-colorpicker-alpha-slider" style="background-size: 100% 100%, 1em 1em, 1em 1em;">
-    <div role="slider" tabindex="0" aria-label="Tranparency" aria-valuemin="0" aria-valuenow="61" aria-valuemax="100" class="alpha-range-thumb" style="left: 61%;">
-        <b-tooltip-stub active="true" type="is-primary" label="61%" position="is-top" triggers="hover" size="is-medium" animated="true" animation="fade" autoclose="true">
-            &nbsp;
-        </b-tooltip-stub>
-    </div>
+  <div role="slider" class="alpha-range-thumb" tabindex="0" aria-label="Tranparency" aria-valuemin="0" aria-valuenow="61" aria-valuemax="100" style="left: 61%;">
+    <b-tooltip-stub label="61%" active="true" type="is-primary" position="is-top" triggers="hover" always="false" square="false" dashed="false" multilined="false" size="is-medium" appendtobody="false" animated="true" animation="fade" autoclose="true"></b-tooltip-stub>
+  </div>
 </div>
 `;

--- a/src/components/colorpicker/__snapshots__/ColorpickerHSLRepresentationSquare.spec.js.snap
+++ b/src/components/colorpicker/__snapshots__/ColorpickerHSLRepresentationSquare.spec.js.snap
@@ -2,11 +2,11 @@
 
 exports[`BColorpickerHSLRepresentationSquare render correctly 1`] = `
 <div class="b-colorpicker-square" style="width: 200px;">
-    <div class="colorpicker-square-slider-hue">
-        <div role="slider" tabindex="0" aria-label="Hue" aria-valuemin="0" aria-valuemax="359" class="hue-range-thumb" style="left: 36.4px; top: 190px; width: 18px;"></div>
-    </div>
-    <div aria-datascales="lightness, saturation" class="colorpicker-square-slider-sl" style="margin: 20px;">
-        <div role="slider" tabindex="0" aria-datavalues="67%, 20%" class="sl-range-thumb" style="left: 67%; top: 80%;"></div>
-    </div>
+  <div class="colorpicker-square-slider-hue">
+    <div role="slider" class="hue-range-thumb" tabindex="0" aria-label="Hue" aria-valuemin="0" aria-valuemax="359" style="left: 36.4px; top: 190px; width: 18px;"></div>
+  </div>
+  <div class="colorpicker-square-slider-sl" style="margin: 20px;" aria-datascales="lightness, saturation">
+    <div role="slider" class="sl-range-thumb" tabindex="0" aria-datavalues="67%, 20%" style="left: 67%; top: 80%;"></div>
+  </div>
 </div>
 `;

--- a/src/components/colorpicker/__snapshots__/ColorpickerHSLRepresentationTriangle.spec.js.snap
+++ b/src/components/colorpicker/__snapshots__/ColorpickerHSLRepresentationTriangle.spec.js.snap
@@ -2,35 +2,35 @@
 
 exports[`BColorpickerHSLRepresentationTriangle render correctly 1`] = `
 <svg viewBox="0 0 200 200" class="b-colorpicker-triangle">
-    <defs>
-        <linearGradient id="cp-triangle-gradient-ligthness-0" x1="0" y1="0" x2="1" y2="0">
-            <stop offset="0%" stop-color="#fff"></stop>
-            <stop offset="100%" stop-color="#000"></stop>
-        </linearGradient>
-        <linearGradient id="cp-triangle-gradient-saturation-0" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="0%" stop-color="hsl(210deg, 100%, 50%)" stop-opacity="1"></stop>
-            <stop offset="100%" stop-color="hsl(210deg, 100%, 50%)" stop-opacity="0"></stop>
-        </linearGradient>
-        <clipPath id="cp-triangle-clip-0">
-            <path d="M2 100a98  98  0 1 1 196 0h-20a-78  78  0 1 0 -156 0a78  78  0 1 0 156 0h20a98  98  0 1 1 -196 0z"></path>
-        </clipPath>
-    </defs>
-    <g class="colorpicker-triangle-slider-hue">
-        <foreignObject x="0" y="0" width="200" height="200" clip-path="url(#cp-triangle-clip-0)">
-            <div class="colorpicker-triangle-hue"></div>
-        </foreignObject>
-        <g style="transform: rotate(210deg);">
-            <foreignObject x="96" y="0" width="8" height="24">
-                <div role="slider" tabindex="0" aria-label="Hue" aria-valuemin="0" aria-valuenow="210" aria-valuemax="360" class="hue-range-thumb"></div>
-            </foreignObject>
-        </g>
+  <defs>
+    <linearGradient id="cp-triangle-gradient-ligthness-0" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#fff"></stop>
+      <stop offset="100%" stop-color="#000"></stop>
+    </linearGradient>
+    <linearGradient id="cp-triangle-gradient-saturation-0" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="hsl(210deg, 100%, 50%)" stop-opacity="1"></stop>
+      <stop offset="100%" stop-color="hsl(210deg, 100%, 50%)" stop-opacity="0"></stop>
+    </linearGradient>
+    <clipPath id="cp-triangle-clip-0">
+      <path d="M2 100a98  98  0 1 1 196 0h-20a-78  78  0 1 0 -156 0a78  78  0 1 0 156 0h20a98  98  0 1 1 -196 0z"></path>
+    </clipPath>
+  </defs>
+  <g class="colorpicker-triangle-slider-hue">
+    <foreignObject x="0" y="0" width="200" height="200" clip-path="url(#cp-triangle-clip-0)">
+      <div class="colorpicker-triangle-hue"></div>
+    </foreignObject>
+    <g style="transform: rotate(210deg);">
+      <foreignObject x="96" y="0" width="8" height="24">
+        <div class="hue-range-thumb" style="" role="slider" tabindex="0" aria-label="Hue" aria-valuemin="0" aria-valuenow="210" aria-valuemax="360"></div>
+      </foreignObject>
     </g>
-    <g role="graphics-datagroup" aria-datascales="lightness, saturation" class="colorpicker-triangle-slider-sl" style="transform: rotate(210deg) translate(50%, 50%);">
-        <path d="M0 -78L67.54998149484 39H-67.54998149484z" fill="url(#cp-triangle-gradient-ligthness-0)"></path>
-        <path d="M0 -78L67.54998149484 39H-67.54998149484z" fill="url(#cp-triangle-gradient-saturation-0)" style="mix-blend-mode: overlay;"></path>
-        <foreignObject x="34.010373654636" y="-44.885000000000005" width="12" height="12">
-            <div tabindex="0" aria-datavalues="67%, 20%" class="sl-range-thumb"></div>
-        </foreignObject>
-    </g>
+  </g>
+  <g class="colorpicker-triangle-slider-sl" style="transform: rotate(210deg) translate(50%, 50%);" role="graphics-datagroup" aria-datascales="lightness, saturation">
+    <path d="M0 -78L67.54998149484 39H-67.54998149484z" fill="url(#cp-triangle-gradient-ligthness-0)"></path>
+    <path d="M0 -78L67.54998149484 39H-67.54998149484z" fill="url(#cp-triangle-gradient-saturation-0)" style="mix-blend-mode: overlay;"></path>
+    <foreignObject x="34.010373654636" y="-44.885000000000005" width="12" height="12">
+      <div class="sl-range-thumb" tabindex="0" aria-datavalues="67%, 20%"></div>
+    </foreignObject>
+  </g>
 </svg>
 `;


### PR DESCRIPTION
Part of the series of PRs to port unit tests.

The following command should pass:
```sh
npx jest src/components/colorpicker 
```

You will see the following warning. This is due to the issue #35 but should not matter to the test results:
> [Vue warn]: Failed to resolve component: b-button

You will also see the following warning. This is due to the issue #34 but should not matter to the test results:
> [Vue warn]: Property "mobileNative" was accessed during render but is not defined on instance.

Related to:
- #1

## Proposed Changes

- Port spec for Colorpicker
- Port spec for ColorpickerAlphaSlider
- Port spec for ColorpickerHSLRepresentationSquare
- Port spec for ColorpickerHSLRepresentationTriangle