### PR TITLE
Port spec for Rate

### DIFF
--- a/src/components/rate/Rate.spec.js
+++ b/src/components/rate/Rate.spec.js
@@ -9,79 +9,79 @@ describe('BRate', () => {
     })
 
     it('is vue instance', () => {
-        expect(wrapper.name()).toBe('BRate')
-        expect(wrapper.isVueInstance()).toBeTruthy()
+        expect(wrapper.vm).toBeTruthy()
+        expect(wrapper.vm.$options.name).toBe('BRate')
     })
 
-    it('renders props.customText', () => {
-        wrapper.setProps({ customText: 'Points' })
+    it('renders props.customText', async () => {
+        await wrapper.setProps({ customText: 'Points' })
         expect(wrapper.text()).toMatch('Points')
     })
 
-    it('reacts when value changes', () => {
+    it('reacts when value changes', async () => {
         const value = 5.5
         const percent = 50
-        wrapper.setProps({ value })
+        await wrapper.setProps({ modelValue: value })
         expect(wrapper.vm.newValue).toBe(value)
         expect(wrapper.vm.valueDecimal).toBe(percent)
         expect(wrapper.vm.halfStyle).toBe(`width:${percent}%`)
 
-        wrapper.setProps({ disabled: true })
+        await wrapper.setProps({ disabled: true })
         expect(wrapper.vm.checkHalf(value + 0.5)).toBeTruthy()
         expect(wrapper.vm.rateClass(value + 0.5)).toBe('set-half')
     })
 
-    it('is displaying correctly', () => {
+    it('is displaying correctly', async () => {
         const texts = ['foo', 'bar']
         let value = 1
 
-        wrapper.setProps({ value, texts, showText: true })
+        await wrapper.setProps({ modelValue: value, texts, showText: true })
         expect(wrapper.vm.showMe).toBe(texts[value - 1])
 
-        wrapper.setProps({ showScore: true })
+        await wrapper.setProps({ showScore: true })
         expect(wrapper.vm.showMe).toBe(`${value}`)
 
-        wrapper.setProps({ disabled: true })
+        await wrapper.setProps({ disabled: true })
         expect(wrapper.vm.showMe).toBe(`${value}`)
 
         value = 0
-        wrapper.setProps({ value, showScore: true })
+        await wrapper.setProps({ modelValue: value, showScore: true })
         expect(wrapper.vm.showMe).toBe('')
     })
 
-    it('manage methods correctly', () => {
+    it('manage methods correctly', async () => {
         const event = {
             stopPropagation: jest.fn()
         }
         let value = 0
 
-        wrapper.setProps({ value, disabled: true })
+        await wrapper.setProps({ modelValue: value, disabled: true })
         wrapper.vm.previewRate(value + 1, event)
         expect(wrapper.vm.hoverValue).toBe(value)
 
         value = 1
-        wrapper.setProps({ disabled: false })
+        await wrapper.setProps({ disabled: false })
         wrapper.vm.previewRate(value, event)
         expect(wrapper.vm.hoverValue).toBe(value)
 
         expect(event.stopPropagation).toHaveBeenCalledTimes(1)
 
-        wrapper.setProps({ disabled: true })
+        await wrapper.setProps({ disabled: true })
         wrapper.vm.resetNewValue()
         expect(wrapper.vm.hoverValue).toBe(value)
 
         value = 0
-        wrapper.setProps({ disabled: false })
+        await wrapper.setProps({ disabled: false })
         wrapper.vm.resetNewValue()
         expect(wrapper.vm.hoverValue).toBe(value)
 
         value = 0
-        wrapper.setProps({ disabled: true })
+        await wrapper.setProps({ disabled: true })
         wrapper.vm.confirmValue(value + 1)
         expect(wrapper.vm.newValue).toBe(value)
 
         value = 1
-        wrapper.setProps({ disabled: false })
+        await wrapper.setProps({ disabled: false })
         wrapper.vm.confirmValue(value)
         expect(wrapper.vm.newValue).toBe(value)
     })


### PR DESCRIPTION
Part of the series of PRs to port unit tests.

The following command should pass:
```sh
npx jest src/components/rate
```

Related to:
- #1

## Proposed Changes

- Port spec for Rate