### PR TITLE
Port spec for Tag

### DIFF
--- a/src/components/tag/Tag.spec.js
+++ b/src/components/tag/Tag.spec.js
@@ -9,24 +9,22 @@ describe('BTag', () => {
     })
 
     it('is called', () => {
-        expect(wrapper.name()).toBe('BTag')
-        expect(wrapper.isVueInstance()).toBeTruthy()
+        expect(wrapper.vm).toBeTruthy()
+        expect(wrapper.vm.$options.name).toBe('BTag')
     })
 
     it('render correctly', () => {
         expect(wrapper.html()).toMatchSnapshot()
     })
 
-    it('emit close event when closing if not disabled', () => {
-        wrapper.setProps({ disabled: false })
+    it('emit close event when closing if not disabled', async () => {
+        await wrapper.setProps({ disabled: false })
 
-        const close = jest.fn()
-        wrapper.vm.$on('close', close)
         wrapper.vm.close()
 
-        wrapper.setProps({ disabled: true })
+        await wrapper.setProps({ disabled: true })
         wrapper.vm.close()
 
-        expect(close).toHaveBeenCalledTimes(1)
+        expect(wrapper.emitted().close).toHaveLength(1)
     })
 })

--- a/src/components/tag/Taglist.spec.js
+++ b/src/components/tag/Taglist.spec.js
@@ -9,8 +9,8 @@ describe('BTaglist', () => {
     })
 
     it('is called', () => {
-        expect(wrapper.name()).toBe('BTaglist')
-        expect(wrapper.isVueInstance()).toBeTruthy()
+        expect(wrapper.vm).toBeTruthy()
+        expect(wrapper.vm.$options.name).toBe('BTaglist')
     })
 
     it('render correctly', () => {

--- a/src/components/tag/__snapshots__/Tag.spec.js.snap
+++ b/src/components/tag/__snapshots__/Tag.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BTag render correctly 1`] = `
-<span class="tag"><!----> <span class=""></span>
-<!----></span>
+<span class="tag"><!--v-if--><span class=""></span>
+<!--v-if--></span>
 `;


### PR DESCRIPTION
Part of the series of PRs to port unit tests.

The following command should pass:
```sh
npx jest src/components/tag/
```

You will see the following warning while running the tests. This is due to #40 but should not matter to the test results:
> [Vue warn]: Failed to resolve component: b-icon

Related to:
- #1

## Proposed Changes

- Port spec for Tag
- Port spec for Taglist