### PR TITLE
Port spec for Upload

### DIFF
--- a/src/components/upload/Upload.spec.js
+++ b/src/components/upload/Upload.spec.js
@@ -9,8 +9,8 @@ describe('BUpload', () => {
     })
 
     it('is called', () => {
-        expect(wrapper.name()).toBe('BUpload')
-        expect(wrapper.isVueInstance()).toBeTruthy()
+        expect(wrapper.vm).toBeTruthy()
+        expect(wrapper.vm.$options.name).toBe('BUpload')
     })
 
     it('render correctly', () => {

--- a/src/components/upload/__snapshots__/Upload.spec.js.snap
+++ b/src/components/upload/__snapshots__/Upload.spec.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BUpload render correctly 1`] = `<label class="upload control"> <input type="file"></label>`;
+exports[`BUpload render correctly 1`] = `<label class="upload control"><input type="file"></label>`;


### PR DESCRIPTION
Part of the series of PRs to port unit tests.

The following command should pass:
```sh
npx jest src/components/upload
```

Related to:
- #1

## Proposed Changes

- Port spec for Upload