### PR TITLE
Port spec for config

### DIFF
--- a/src/utils/config.spec.js
+++ b/src/utils/config.spec.js
@@ -3,7 +3,7 @@ import config, { setOptions } from '@utils/config'
 describe('Config', () => {
     describe('Test options', () => {
         test('defaultToastDuration option should be 1000', () => {
-            setOptions(Object.assign(config, {defaultToastDuration: 1000}))
+            setOptions(Object.assign(config, { defaultToastDuration: 1000 }))
             expect(config.defaultToastDuration).toBe(1000)
         })
     })


### PR DESCRIPTION
Part of the series of PRs to port unit tests.

The following command should pass:
```sh
npx jest src/utils/config.spec.js
```

Related to:
- #1

## Proposed Changes

- Fix a lint error in config.spec.js