### PR TITLE
Fix: BCollapse warns non-function value for default slot (#26)

### DIFF
--- a/src/components/collapse/Collapse.vue
+++ b/src/components/collapse/Collapse.vue
@@ -55,19 +55,15 @@ export default {
                 class: 'collapse-trigger',
                 onClick: this.toggle
             },
-            {
-                default: () => {
-                    return this.$slots.trigger
-                        ? this.$slots.trigger({ open: this.isOpen })
-                        : undefined
-                }
-            }
+            this.$slots.trigger
+                ? this.$slots.trigger({ open: this.isOpen })
+                : undefined
         )
         const content = withDirectives(
             createElement(
                 Transition,
                 { name: this.animation },
-                [
+                () => [
                     createElement(
                         'div',
                         {
@@ -83,13 +79,7 @@ export default {
         return createElement(
             'div',
             { class: 'collapse' },
-            {
-                default: () => {
-                    return this.position === 'is-top'
-                        ? [trigger, content]
-                        : [content, trigger]
-                }
-            }
+            this.position === 'is-top' ? [trigger, content] : [content, trigger]
         )
     }
 }


### PR DESCRIPTION
Fixes:
- #26

## Proposed Changes

- Use a function-form slot for the default slot (child) of a `Transition` component.
- Replace redundant object-form slots given to `div` elements with array-form slots. `this.$slots.trigger({...})` returns an array, btw.