### PR TITLE
Fix: No plugins available on programmatically opened Modal.open (#101)

### DIFF
--- a/docs/pages/components/modal/examples/ExProgrammatic.vue
+++ b/docs/pages/components/modal/examples/ExProgrammatic.vue
@@ -18,18 +18,7 @@
 <script>
     import { h } from 'vue'
 
-    // `modal.open` can no longer resolve components registered in
-    // the current app because it creates a brand-new app.
-    // so components referenced from the component specified to the `component`
-    // option have to be explicitly registered.
-    import { BButton } from '../../../../../src/components/button'
-    import { BCheckbox } from '../../../../../src/components/checkbox'
-    import { BField } from '../../../../../src/components/field'
-    import { BInput } from '../../../../../src/components/input'
-
     const ModalForm = {
-        // see above
-        components: { BButton, BCheckbox, BField, BInput },
         props: ['email', 'password'],
         template: `
             <form action="">

--- a/src/components/dialog/index.js
+++ b/src/components/dialog/index.js
@@ -3,10 +3,10 @@ import { createApp, h as createElement } from 'vue'
 import Dialog from './Dialog.vue'
 
 import config from '../../utils/config'
-import { merge, getComponentFromVNode } from '../../utils/helpers'
+import { merge, copyAppContext, getComponentFromVNode } from '../../utils/helpers'
 import { use, registerComponent, registerComponentProgrammatic } from '../../utils/plugins'
 
-function open(propsData) {
+function open(propsData, app) {
     let slot
     if (Array.isArray(propsData.message)) {
         slot = propsData.message
@@ -14,6 +14,7 @@ function open(propsData) {
     }
     function createDialog(onConfirm, onCancel) {
         const container = document.createElement('div')
+        // Vue 3 requires a new app to mount another component
         const vueInstance = createApp({
             data() {
                 return {
@@ -64,6 +65,9 @@ function open(propsData) {
                 return this.dialogVNode
             }
         })
+        if (app) {
+            copyAppContext(app, vueInstance)
+        }
         return vueInstance.mount(container)
     }
     if (!config.defaultProgrammaticPromise) {
@@ -77,7 +81,11 @@ function open(propsData) {
     }
 }
 
-const DialogProgrammatic = {
+class DialogProgrammatic {
+    constructor(app) {
+        this.app = app // may be undefined in the testing environment
+    }
+
     alert(params) {
         if (typeof params === 'string') {
             params = {
@@ -88,26 +96,28 @@ const DialogProgrammatic = {
             canCancel: false
         }
         const propsData = merge(defaultParam, params)
-        return open(propsData)
-    },
+        return open(propsData, this.app)
+    }
+
     confirm(params) {
         const defaultParam = {}
         const propsData = merge(defaultParam, params)
-        return open(propsData)
-    },
+        return open(propsData, this.app)
+    }
+
     prompt(params) {
         const defaultParam = {
             hasInput: true
         }
         const propsData = merge(defaultParam, params)
-        return open(propsData)
+        return open(propsData, this.app)
     }
 }
 
 const Plugin = {
     install(Vue) {
         registerComponent(Vue, Dialog)
-        registerComponentProgrammatic(Vue, 'dialog', DialogProgrammatic)
+        registerComponentProgrammatic(Vue, 'dialog', new DialogProgrammatic(Vue))
     }
 }
 

--- a/src/components/loading/index.js
+++ b/src/components/loading/index.js
@@ -2,16 +2,21 @@ import { createApp, h as createElement } from 'vue'
 
 import Loading from './Loading.vue'
 
-import { merge, getComponentFromVNode } from '../../utils/helpers'
+import { merge, copyAppContext, getComponentFromVNode } from '../../utils/helpers'
 import { use, registerComponent, registerComponentProgrammatic } from '../../utils/plugins'
 
-const LoadingProgrammatic = {
+class LoadingProgrammatic {
+    constructor(app) {
+        this.app = app // may be undefined in the testing environment
+    }
+
     open(params) {
         const defaultParam = {
             programmatic: true
         }
         const propsData = merge(defaultParam, params)
         const container = document.createElement('div')
+        // Vue 3 requires a new app to mount another component
         const vueInstance = createApp({
             data() {
                 return {
@@ -46,6 +51,9 @@ const LoadingProgrammatic = {
                 return this.loadingVNode
             }
         })
+        if (this.app) {
+            copyAppContext(this.app, vueInstance)
+        }
         return vueInstance.mount(container)
     }
 }
@@ -53,7 +61,7 @@ const LoadingProgrammatic = {
 const Plugin = {
     install(Vue) {
         registerComponent(Vue, Loading)
-        registerComponentProgrammatic(Vue, 'loading', LoadingProgrammatic)
+        registerComponentProgrammatic(Vue, 'loading', new LoadingProgrammatic(Vue))
     }
 }
 

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -332,3 +332,28 @@ export function getComponentFromVNode(vnode) {
     }
     return component.expose ? component.expose : component.proxy
 }
+
+// Copies the context from a given app to another app.
+//
+// This function is necessary to programmatically mount a component; e.g.,
+// Modal.
+// Since Vue 3's app can mount only one component, we have to create a new app
+// to mount another new component.
+// If we create a new app with `createApp` API, no context (e.g., installed
+// components, directives) is available on the new app.
+// This function can copy the context from the host app to the new app.
+//
+// Depends on what Vue internally does: https://github.com/vuejs/core/blob/b775b71c788499ec7ee58bc2cf4cd04ed388e072/packages/runtime-core/src/apiCreateApp.ts#L170-L190
+export function copyAppContext(src, dest) {
+    // replacing _context won't work because methods of app bypasses app._context
+    const { _context: srcContext } = src
+    const { _context: destContext } = dest
+    destContext.config = srcContext.config
+    destContext.mixins = srcContext.mixins
+    destContext.components = srcContext.components
+    destContext.directives = srcContext.directives
+    destContext.provdes = srcContext.provides
+    destContext.optionsCache = srcContext.optionsCache
+    destContext.propsCache = srcContext.propsCache
+    destContext.emitsCache = srcContext.emitsCache
+}


### PR DESCRIPTION
Fixes #101

I want to include fixes to unit tests in the PR. So this PR will be a draft until all the PRs related to unit tests are merged.

## Proposed Changes

- Copy the app context of the host app to a new Vue app mounting `Modal`. Fix similar problems on components that can be programmatically opened:
    - `Dialog`
    - `Loading`
    - `Notification`
    - `Snackbar`
    - `Toast`
- Introduce a new helper function `copyAppContext` that copies the app context of an app to another app.
