### PR TITLE
fix(lib): programmatic open tests

### DIFF
--- a/src/components/loading/Loading.spec.js
+++ b/src/components/loading/Loading.spec.js
@@ -71,7 +71,7 @@ describe('BLoading', () => {
 
             onClose = jest.fn()
             spyOnAppendChild = jest.spyOn(window.document.body, 'appendChild')
-            loading = LoadingProgrammatic.open({ onClose })
+            loading = new LoadingProgrammatic().open({ onClose })
             await loading.$nextTick() // makes sure DOM is updated
         })
 
@@ -117,7 +117,7 @@ describe('BLoading', () => {
 
             container = document.createElement('div')
             spyOnAppendChild = jest.spyOn(container, 'appendChild')
-            loading = LoadingProgrammatic.open({
+            loading = new LoadingProgrammatic().open({
                 container
             })
             await loading.$nextTick() // makes sure DOM is updated

--- a/src/components/modal/Modal.spec.js
+++ b/src/components/modal/Modal.spec.js
@@ -105,7 +105,7 @@ describe('BModal', () => {
         })
 
         it('should be able to be manually closed', async () => {
-            const modal = ModalProgrammatic.open({
+            const modal = new ModalProgrammatic().open({
                 content: 'content'
             })
             await modal.$nextTick() // makes sure DOM is updated

--- a/src/components/toast/Toast.spec.js
+++ b/src/components/toast/Toast.spec.js
@@ -44,7 +44,7 @@ describe('BToast', () => {
                 duration: 1000,
                 onClose: jest.fn()
             }
-            ToastProgrammatic.open(params)
+            new ToastProgrammatic().open(params)
             jest.advanceTimersByTime(500)
             expect(params.onClose).not.toHaveBeenCalled()
             jest.advanceTimersByTime(500)
@@ -58,7 +58,7 @@ describe('BToast', () => {
                 indefinite: true,
                 onClose: jest.fn()
             }
-            const toast = ToastProgrammatic.open(params)
+            const toast = new ToastProgrammatic().open(params)
             jest.advanceTimersByTime(10000)
             expect(params.onClose).not.toHaveBeenCalled()
             toast.close()


### PR DESCRIPTION
Fixes:
- fixes #101

## Proposed Changes

- Fix specs for `Loading`, `Modal`, and `Toast`
    - Treat `*Programmatic` as a class instead of a constant