### PR TITLE
Bump package-lock.json version → 0.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ntohq/buefy-next",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ntohq/buefy-next",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "7.18.9",


### PR DESCRIPTION
Related to:
- #103

## Proposed Changes

- Bump `version` in `package-lock.json` to 0.1.2