### PR TITLE
MigrateToLerna: fix missing icons on the Home view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -761,12 +761,6 @@
         "node": "^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@mdi/font": {
-      "version": "7.3.67",
-      "resolved": "https://registry.npmjs.org/@mdi/font/-/font-7.3.67.tgz",
-      "integrity": "sha512-SWxvzRbUQRfewlIV+OF4/YF4DkeTjMWoT8Hh9yeU/5UBVdJZj9Uf4a9+cXjknSIhIaMxZ/4N1O/s7ojApOOGjg==",
-      "dev": true
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -8393,7 +8387,7 @@
       },
       "devDependencies": {
         "@fortawesome/fontawesome-free": "^6.4.2",
-        "@mdi/font": "^7.2.96",
+        "@mdi/font": "^6.9.96",
         "@vitejs/plugin-vue": "^4.2.3",
         "@vue/shared": "^3.3.4",
         "axios": "^1.5.1",
@@ -8412,6 +8406,12 @@
         "vue-breakpoint-mixin": "1.2.2",
         "vue-router": "^4.2.5"
       }
+    },
+    "packages/docs/node_modules/@mdi/font": {
+      "version": "6.9.96",
+      "resolved": "https://registry.npmjs.org/@mdi/font/-/font-6.9.96.tgz",
+      "integrity": "sha512-z3QVZStyHVwkDsFR7A7F2PIvZJPWgdSFw4BEEy2Gc9HUN5NfK9mGbjgaYClRcbMWiYEV45srmiYtczmBtCqR8w==",
+      "dev": true
     }
   }
 }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@fortawesome/fontawesome-free": "^6.4.2",
-    "@mdi/font": "^7.2.96",
+    "@mdi/font": "^6.9.96",
     "@vitejs/plugin-vue": "^4.2.3",
     "@vue/shared": "^3.3.4",
     "axios": "^1.5.1",

--- a/packages/docs/src/components/TheNavbar.vue
+++ b/packages/docs/src/components/TheNavbar.vue
@@ -30,7 +30,7 @@
                     target="_blank"
                     title="Github"
                 >
-                    <b-icon icon="github-circle" />
+                    <b-icon icon="github" />
                 </a>
 
                 <a


### PR DESCRIPTION
See discord:
- https://discord.com/channels/972670088610218104/1161511034209710133/1161511037959405640

## Proposed Changes

- Downgrade `@mdi/font` to v6.9.96, because the Discord icon was removed since v7.x
    - This should be considered a temporary workaround until we support another icon source like [Simple Icons](https://simpleicons.org)
- Rename `github-circle` to `github`