### PR TITLE
MigrateToLerna: miscellaneous updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3612,12 +3612,12 @@
       "dev": true
     },
     "node_modules/highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "version": "11.9.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.9.0.tgz",
+      "integrity": "sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw==",
       "dev": true,
       "engines": {
-        "node": "*"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/hosted-git-info": {
@@ -8395,7 +8395,7 @@
         "bulma-css-vars": "0.8.0",
         "cleave.js": "1.0.1",
         "clipboard": "^2.0.11",
-        "highlight.js": "^10.7.3",
+        "highlight.js": "^11.9.0",
         "lodash": "^4.17.21",
         "sass": "^1.68.0",
         "scrollreveal": "3.3.6",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -31,7 +31,7 @@
     "bulma-css-vars": "0.8.0",
     "cleave.js": "1.0.1",
     "clipboard": "^2.0.11",
-    "highlight.js": "^10.7.3",
+    "highlight.js": "^11.9.0",
     "lodash": "^4.17.21",
     "sass": "^1.68.0",
     "scrollreveal": "3.3.6",

--- a/packages/docs/src/assets/scss/main.scss
+++ b/packages/docs/src/assets/scss/main.scss
@@ -28,7 +28,7 @@
 @import "../../../../buefy-next/src/scss/buefy";
 
 // Highlight.js
-@import "highlight.js/styles/atelier-cave-light.css";
+@import "highlight.js/styles/base16/atelier-cave-light.css";
 
 // MDI
 $mdi-font-path: "@mdi/font/fonts";

--- a/packages/docs/src/components/SidebarSearch.vue
+++ b/packages/docs/src/components/SidebarSearch.vue
@@ -39,7 +39,7 @@
                                 ? null
                                 :'sidebarSearchNoresult'
                             "
-                            @input="search"
+                            @update:model-value="search"
                             maxlength="32"
                             :has-counter="false"
                         />

--- a/packages/docs/src/components/TheFooter.vue
+++ b/packages/docs/src/components/TheFooter.vue
@@ -17,7 +17,7 @@
                                     class="button"
                                     href="https://github.com/buefy/buefy"
                                     target="_blank">
-                                    <b-icon icon="github-circle"/>
+                                    <b-icon icon="github"/>
                                     <span>GitHub</span>
                                 </a>
                             </p>

--- a/packages/docs/src/main.js
+++ b/packages/docs/src/main.js
@@ -71,8 +71,7 @@ vueApp.component('VariablesView', VariablesView)
 vueApp.component('Example', Example)
 
 vueApp.directive('highlight', {
-    deep: true,
-    bind(el, binding) {
+    beforeMount(el, binding) {
         // On first bind, highlight all targets
         const targets = el.querySelectorAll('code')
         for (const target of targets) {
@@ -81,16 +80,16 @@ vueApp.directive('highlight', {
             if (binding.value) {
                 target.innerHTML = binding.value
             }
-            hljs.highlightBlock(target)
+            hljs.highlightElement(target)
         }
     },
-    componentUpdated(el, binding) {
+    updated(el, binding) {
         // After an update, re-fill the content and then highlight
         const targets = el.querySelectorAll('code')
         for (const target of targets) {
             if (binding.value) {
                 target.innerHTML = binding.value
-                hljs.highlightBlock(target)
+                hljs.highlightElement(target)
             }
         }
     }

--- a/packages/docs/src/pages/Home.vue
+++ b/packages/docs/src/pages/Home.vue
@@ -51,7 +51,7 @@
                 <div class="container">
                     <div class="columns">
                         <div class="column has-text-centered features">
-                            <b-icon icon="github-circle" size="is-large"/>
+                            <b-icon icon="github" size="is-large"/>
                             <p class="title is-4"><strong>Free</strong></p>
                             <p class="subtitle">Open source on <strong><a href="https://github.com/buefy/buefy" target="_blank">GitHub</a></strong></p>
                         </div>

--- a/packages/docs/src/pages/Home.vue
+++ b/packages/docs/src/pages/Home.vue
@@ -151,7 +151,7 @@
     import ScrollReveal from 'scrollreveal'
     import TheNavbar from '../components/TheNavbar'
     import TheFooter from '../components/TheFooter'
-    import Package from '../../package.json'
+    import Package from '../../../../package.json'
     import expoData from '@/data/expo'
     import sponsorsData from '@/data/sponsors'
 


### PR DESCRIPTION
## Proposed Changes

- Fix syntax highlighting by making the definition of the `highlight` directive compliant with Vue 3
    - Additionally bump `highlight.js` to v11.9.0
- Fix the search feature
- Fix the version displayed on the Home view
- Fix the GitHub icon on the Home view

## Action needed

You have to run `npm install` since `highlight.js` is upgraded.