### PR TITLE
MigrateToLerna: fix missing BMenuList in production

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4021,6 +4021,25 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/copyfiles": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.4.1.tgz",
+      "integrity": "sha512-fereAvAvxDrQDOXybk3Qu3dPbOoKoysFMWtkY3mv5BsL8//OSZVL5DCLYqgRfY5cWirgRzlC+WSrxp6Bo3eNZg==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.0.5",
+        "minimatch": "^3.0.3",
+        "mkdirp": "^1.0.4",
+        "noms": "0.0.0",
+        "through2": "^2.0.1",
+        "untildify": "^4.0.0",
+        "yargs": "^16.1.0"
+      },
+      "bin": {
+        "copyfiles": "copyfiles",
+        "copyup": "copyfiles"
+      }
+    },
     "node_modules/core-js-compat": {
       "version": "3.33.1",
       "dev": true,
@@ -6649,6 +6668,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/noms": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
+      "integrity": "sha512-lNDU9VJaOPxUmXcLb+HQFeUgQQPtMI24Gt6hgfuMHRJgMRHMF/qZ4HJD3GDru4sSw9IQl2jPjAYnQrdIeLbwow==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "~1.0.31"
+      }
+    },
+    "node_modules/noms/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
+    },
+    "node_modules/noms/node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/noms/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+      "dev": true
+    },
     "node_modules/nopt": {
       "version": "6.0.0",
       "dev": true,
@@ -9236,6 +9289,15 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/upath": {
       "version": "2.0.1",
       "dev": true,
@@ -9777,6 +9839,7 @@
         "bulma-css-vars": "0.8.0",
         "cleave.js": "1.0.1",
         "clipboard": "^2.0.11",
+        "copyfiles": "^2.4.1",
         "highlight.js": "^11.9.0",
         "lodash": "^4.17.21",
         "sass": "^1.68.0",

--- a/packages/buefy-next/src/components/menu/index.js
+++ b/packages/buefy-next/src/components/menu/index.js
@@ -7,7 +7,9 @@ import { use, registerComponent } from '../../utils/plugins'
 const Plugin = {
     install(Vue) {
         registerComponent(Vue, Menu)
-        registerComponent(Vue, MenuList)
+        // explicit `name` is needed to avoid name mangling of
+        // Functional Component in production
+        registerComponent(Vue, MenuList, 'BMenuList')
         registerComponent(Vue, MenuItem)
     }
 }

--- a/packages/buefy-next/src/utils/plugins.js
+++ b/packages/buefy-next/src/utils/plugins.js
@@ -5,8 +5,10 @@ export const use = (plugin) => {
     }
 }
 
-export const registerComponent = (Vue, component) => {
-    Vue.component(component.name, component)
+// use `name` to register a Functional Component which will become unresolvable
+// in production build due to name mangling.
+export const registerComponent = (Vue, component, name) => {
+    Vue.component(name || component.name, component)
 }
 
 export const registerComponentProgrammatic = (Vue, property, component) => {

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "vite build && cp netlify.toml dist/",
+    "build": "vite build && copyfiles --flat netlify.toml dist/",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -31,6 +31,7 @@
     "bulma-css-vars": "0.8.0",
     "cleave.js": "1.0.1",
     "clipboard": "^2.0.11",
+    "copyfiles": "^2.4.1",
     "highlight.js": "^11.9.0",
     "lodash": "^4.17.21",
     "sass": "^1.68.0",


### PR DESCRIPTION
## Proposed Changes

- Explicitly give name to `BMenuList` when it is registered. `BMenuList.name` is valid in development but becomes meaningless in production due to name mangling.
    - Add an optional `name` parameter to the `registerComponent` utility function
- Replace `cp` command in the `build` script in `docs` package with `copyfiles` to avoid the error due to missing `cp` command on Windows Command Prompt

## Action Needed

Since a new package `copyfiles` is introduced, you have to run `npm install`.