### PR TITLE
MigrateToLerna: isolate docs from the core source code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9826,6 +9826,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@ntohq/buefy-next": "*",
         "bulma": "^0.9.4",
         "vue": "^3.3.4"
       },

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -18,6 +18,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@ntohq/buefy-next": "*",
     "bulma": "^0.9.4",
     "vue": "^3.3.4"
   },

--- a/packages/docs/src/assets/scss/main.scss
+++ b/packages/docs/src/assets/scss/main.scss
@@ -2,7 +2,7 @@
 @import "bulma/sass/utilities/_all";
 
 // Buefy vars
-@import "../../../../buefy-next/src/scss/utils/_all";
+@import "@ntohq/buefy-next/src/scss/utils/_all";
 
 // Docs variables
 @import "_variables";
@@ -25,7 +25,7 @@
 @import "bulma/bulma";
 
 // Buefy
-@import "../../../../buefy-next/src/scss/buefy";
+@import "@ntohq/buefy-next/src/scss/buefy";
 
 // Highlight.js
 @import "highlight.js/styles/base16/atelier-cave-light.css";

--- a/packages/docs/src/main.js
+++ b/packages/docs/src/main.js
@@ -3,7 +3,7 @@ import App from './App.vue'
 import { createDocsRouter } from './router'
 import Emitter from 'tiny-emitter'
 
-import Buefy from '../../buefy-next/src/'
+import { default as Buefy, createNewEvent } from '@ntohq/buefy-next'
 import Axios from 'axios'
 // TODO: use vue3-progressbar?
 // import VueProgressBar from 'vue-progressbar'
@@ -11,7 +11,6 @@ import Axios from 'axios'
 // import VueAnalytics from 'vue-analytics'
 import Bluebird from 'bluebird'
 import hljs from 'highlight.js'
-import { createNewEvent } from '../../buefy-next/src/utils/helpers'
 
 import ApiView from './components/ApiView.vue'
 import CodeView from './components/CodeView.vue'

--- a/packages/docs/src/pages/components/colorpicker/examples/ExAlpha.vue
+++ b/packages/docs/src/pages/components/colorpicker/examples/ExAlpha.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script>
-import Color from '../../../../../../buefy-next/src/utils/color'
+import { Color } from '@ntohq/buefy-next'
 
 export default {
     data() {

--- a/packages/docs/src/pages/components/colorpicker/examples/ExFields.vue
+++ b/packages/docs/src/pages/components/colorpicker/examples/ExFields.vue
@@ -91,7 +91,7 @@
 </template>
 
 <script>
-import Color from '../../../../../../buefy-next/src/utils/color'
+import { Color } from '@ntohq/buefy-next'
 
 export default {
     data() {

--- a/packages/docs/src/pages/components/colorpicker/examples/ExFormatter.vue
+++ b/packages/docs/src/pages/components/colorpicker/examples/ExFormatter.vue
@@ -22,7 +22,7 @@
 </template>
 
 <script>
-import Color from '../../../../../../buefy-next/src/utils/color'
+import { Color } from '@ntohq/buefy-next'
 
 export default {
     data() {

--- a/packages/docs/src/pages/components/colorpicker/examples/ExRepresentation.vue
+++ b/packages/docs/src/pages/components/colorpicker/examples/ExRepresentation.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script>
-import Color from '../../../../../../buefy-next/src/utils/color'
+import { Color } from '@ntohq/buefy-next'
 
 export default {
     data() {


### PR DESCRIPTION
## Proposed Changes

- Make `docs` package not directly import the source code in `buefy-next` but import `@ntohq/buefy-next` as a package
    - In this way, `docs` can serve as a more realistic example for package users

## Action Needed

You have to run `npm install`.
You have to build `packages/buefy-next` before `packages/docs`, or run the following command:
```sh
npm run --workspaces build
```