### PR TITLE
MigrateToLerna: restore hot reloading

### DIFF
--- a/packages/docs/.eslintignore
+++ b/packages/docs/.eslintignore
@@ -1,1 +1,2 @@
 /src/pages
+/vite.config.js

--- a/packages/docs/vite.config.js
+++ b/packages/docs/vite.config.js
@@ -87,6 +87,20 @@ export default defineConfig({
         }
       },
     },
+    {
+      // replaces `@ntohq/buefy-next` with the path to the source code
+      // // in development to ease debugging
+      name: 'link-buefy-next-src',
+      apply: 'serve', // development only
+      resolveId: {
+        order: 'pre', // otherwise, IDs become "plugin-vue:export-helper"
+        handler(id) {
+          if (id === '@ntohq/buefy-next') {
+            return path.resolve(__dirname, '../buefy-next/src/index.js')
+          }
+        },
+      },
+    },
   ],
   resolve: {
     alias: {


### PR DESCRIPTION
## Proposed Changes

- Restore hot reloading of `packges/docs` while debugging with `npm run -w docs dev`
    - Changes in `packages/buefy-next` trigger hot reloading of `packages/docs`
    - You can `npm run -w docs dev` without building `packages/buefy-next`
- Apply no ESLint on `vite.config.js`