### PR TITLE
MigrateToLerna: restore vetur script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8200,6 +8200,15 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/espree": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
@@ -18553,6 +18562,7 @@
         "@vue/vue3-jest": "^29.2.6",
         "babel-jest": "^29.7.0",
         "clean-css-cli": "^5.6.2",
+        "esm": "^3.2.25",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "jest-serializer-vue": "^3.1.0",

--- a/packages/buefy-next/build/vetur.js
+++ b/packages/buefy-next/build/vetur.js
@@ -2,7 +2,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const buefyDir = path.resolve(__dirname, '../docs/pages/components')
+const buefyDir = path.resolve(__dirname, '../../docs/src/pages/components')
 
 let tags = {}
 let attributes = {}

--- a/packages/buefy-next/package.json
+++ b/packages/buefy-next/package.json
@@ -42,9 +42,10 @@
     "unit": "jest --runInBand --u",
     "lint": "eslint src --ext .js,.vue",
     "lint:fix": "eslint src --ext .js,.vue --fix",
-    "build": "rimraf dist && npm run build:js && npm run build:scss",
+    "build": "rimraf dist && npm run build:js && npm run build:scss && npm run vetur",
     "build:js": "rollup -c && rollup -c --environment MINIFY",
-    "build:scss": "node ./build/banner.js < src/scss/buefy-build.scss | sass --stdin --load-path src/scss > dist/buefy.css && cleancss -o dist/buefy.min.css dist/buefy.css"
+    "build:scss": "node ./build/banner.js < src/scss/buefy-build.scss | sass --stdin --load-path src/scss > dist/buefy.css && cleancss -o dist/buefy.min.css dist/buefy.css",
+    "vetur": "node -r esm build/vetur.js"
   },
   "peerDependencies": {
     "vue": "^3.0.0"
@@ -61,6 +62,7 @@
     "@vue/vue3-jest": "^29.2.6",
     "babel-jest": "^29.7.0",
     "clean-css-cli": "^5.6.2",
+    "esm": "^3.2.25",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "jest-serializer-vue": "^3.1.0",


### PR DESCRIPTION
## Proposed Changes

- Restore `vetur` script
    - It should work as it did before, however, I have not tested the outputs as I am not using [Vetur](https://github.com/vuejs/vetur).

## Action Needed

You have to run `npm install` to update dependencies.