### PR TITLE
MigrateToLerna: Fix the unit testing GitHub Actions workflow

### DIFF
--- a/.github/workflows/unit_testing.yml
+++ b/.github/workflows/unit_testing.yml
@@ -16,7 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x, 20.x]
+        # omits 14.x because some of our devDependencies require 16.x or higher
+        node-version: [16.x, 18.x, 20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     steps:
     - uses: actions/checkout@v4
@@ -25,5 +26,5 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - run: npm -w @ntohq/buefy-next ci
+    - run: npm ci
     - run: npm -w @ntohq/buefy-next test


### PR DESCRIPTION
## Proposed Changes

- Drop Node.js v14 from the build matrix because some of our `devDependencies` require Node.js v16 or higher

I confirmed a [tweaked workflow](https://github.com/kikuomax/buefy/blob/2bf8f3aa765c11502ed1d7ed6a8e153af875c760/.github/workflows/unit_testing.yml) worked:
- On push: <https://github.com/kikuomax/buefy/actions/runs/6844991633>
- On PR: <https://github.com/kikuomax/buefy/actions/runs/6845028556>