### PR TITLE
MigrateToLerna: update npm deploy workflow

### DIFF
--- a/.github/workflows/npm_deploy.yml
+++ b/.github/workflows/npm_deploy.yml
@@ -10,14 +10,15 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # Setup .npmrc file to publish to GitHub Packages
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
           registry-url: 'https://registry.npmjs.org/'
           scope: '@ntohq'
       - run: npm ci
-      - run: npm publish --access public
+      - run: npm -w @ntohq/buefy-next run build
+      - run: npm -w @ntohq/buefy-next publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Proposed Changes

- Update `npm_deploy.yml`:
    - Insert `npm build` before `npm publish`
    - Add the workspace option `-w @ntohq/buefy-next` to `npm` commands except for `npm ci`
- Bump Node.js to v18
- Bump `actions/checkout` to v4