### PR TITLE
Datepicker legacy vue3 support (#112)

### DIFF
--- a/packages/buefy-next/src/components/datepicker/DatepickerMonth.spec.js
+++ b/packages/buefy-next/src/components/datepicker/DatepickerMonth.spec.js
@@ -297,4 +297,41 @@ describe('BDatepickerMonth', () => {
             })
         })
     })
+
+    describe('focus', () => {
+        let wrapper
+        const nextMonth = thisMonth + 1
+        let cellToFocus
+
+        beforeEach(() => {
+            wrapper = shallowMount(BDatepickerMonth, {
+                props: {
+                    monthNames: config.defaultMonthNames,
+                    focused: {
+                        month: config.focusedDate.getMonth(),
+                        year: config.focusedDate.getFullYear()
+                    },
+                    dateCreator
+                }
+            })
+            const refName = `month-${nextMonth}`
+            if (Array.isArray(wrapper.vm.$refs[refName])) {
+                cellToFocus = wrapper.vm.$refs[refName][0]
+            } else {
+                cellToFocus = wrapper.vm.$refs[refName]
+            }
+            jest.spyOn(cellToFocus, 'focus')
+        })
+
+        it('changing month should call focus on the corresponding cell', async () => {
+            await wrapper.setProps({
+                focused: {
+                    month: nextMonth,
+                    year: config.focusedDate.getFullYear()
+                }
+            })
+            await wrapper.vm.$nextTick()
+            expect(cellToFocus.focus).toHaveBeenCalled()
+        })
+    })
 })

--- a/packages/buefy-next/src/components/datepicker/DatepickerMonth.vue
+++ b/packages/buefy-next/src/components/datepicker/DatepickerMonth.vue
@@ -143,13 +143,19 @@ export default {
     watch: {
         focusedMonth(month) {
             const refName = `month-${month}`
-            if (this.$refs[refName] && this.$refs[refName].length > 0) {
-                this.$nextTick(() => {
-                    if (this.$refs[refName][0]) {
-                        this.$refs[refName][0].focus()
-                    }
-                }) // $nextTick needed when year is changed
-            }
+            this.$nextTick(() => {
+                // Vue ≥ v3.0 < v3.2.25, refs in v-for are stored as a single object,
+                // but ≥ v3.2.25, refs in v-for are stored in an array (same as Vue 2)
+                let cell
+                if (Array.isArray(this.$refs[refName])) {
+                    cell = this.$refs[refName][0]
+                } else {
+                    cell = this.$refs[refName]
+                }
+                if (cell) {
+                    cell.focus()
+                }
+            }) // $nextTick needed when year is changed
         }
     },
     methods: {

--- a/packages/buefy-next/src/components/datepicker/DatepickerTableRow.spec.js
+++ b/packages/buefy-next/src/components/datepicker/DatepickerTableRow.spec.js
@@ -262,4 +262,32 @@ describe('BDatepickerTableRow', () => {
         })
         expect(wrapper.vm.selectableDate(day)).toBeTruthy()
     })
+
+    describe('focus', () => {
+        let wrapper
+        let cellToFocus
+
+        beforeEach(() => {
+            wrapper = shallowMount(BDatepickerTableRow, {
+                props: {
+                    ...props,
+                    month: 1,
+                    day: 1
+                }
+            })
+            const refName = 'day-1-2'
+            if (Array.isArray(wrapper.vm.$refs[refName])) {
+                cellToFocus = wrapper.vm.$refs[refName][0]
+            } else {
+                cellToFocus = wrapper.vm.$refs[refName]
+            }
+            jest.spyOn(cellToFocus, 'focus')
+        })
+
+        it('changing day should call focus on the corresponding cell', async () => {
+            await wrapper.setProps({ day: 2 })
+            await wrapper.vm.$nextTick()
+            expect(cellToFocus.focus).toHaveBeenCalled()
+        })
+    })
 })

--- a/packages/buefy-next/src/components/datepicker/DatepickerTableRow.vue
+++ b/packages/buefy-next/src/components/datepicker/DatepickerTableRow.vue
@@ -96,10 +96,16 @@ export default {
         day(day) {
             const refName = `day-${this.month}-${day}`
             this.$nextTick(() => {
-                if (this.$refs[refName] && this.$refs[refName].length > 0) {
-                    if (this.$refs[refName][0]) {
-                        this.$refs[refName][0].focus()
-                    }
+                // Vue ≥ v3.0 < v3.2.25, refs in v-for are stored as a single object,
+                // but ≥ v3.2.25, refs in v-for are stored in an array (same as Vue 2)
+                let cell
+                if (Array.isArray(this.$refs[refName])) {
+                    cell = this.$refs[refName][0]
+                } else {
+                    cell = this.$refs[refName]
+                }
+                if (cell) {
+                    cell.focus()
                 }
             }) // $nextTick needed when month is changed
         }


### PR DESCRIPTION
Fixes #
- fixes #112

## Proposed Changes

- Modify `DatepickerTableRow` and `DatepickerMonth` so that they work both with Vue v3.2.24 or earlier, and Vue v3.2.25 or later
    - `ref` combined with `v-for` is stored as a single object in `$refs` on Vue v3.2.24 or earlier, but stored in an array on Vue v3.2.25 or later
- Add test cases that test affected behavior