### PR TITLE
Fix: useI18n does not work in a setup script within the context of a programmatically opened Modal (#153)

### DIFF
--- a/packages/buefy-next/src/utils/helpers.js
+++ b/packages/buefy-next/src/utils/helpers.js
@@ -350,6 +350,10 @@ export function getComponentFromVNode(vnode) {
 // This function can copy the context from the host app to the new app.
 //
 // Depends on what Vue internally does: https://github.com/vuejs/core/blob/b775b71c788499ec7ee58bc2cf4cd04ed388e072/packages/runtime-core/src/apiCreateApp.ts#L170-L190
+//
+// This function also should take care of compatiblity with other plugins.
+// We need a generic solution, though, it fixes compatiblity issues of
+// individual plugins for now.
 export function copyAppContext(src, dest) {
     // replacing _context won't work because methods of app bypasses app._context
     const { _context: srcContext } = src


### PR DESCRIPTION
Fixes #
- #153

## Proposed Changes

- Copy the `vue-i18n` specific private field in `copyAppContext`