### PR TITLE
Create Helper Function for Shallow Fields

### DIFF
--- a/packages/docs/src/pages/components/autocomplete/Autocomplete.vue
+++ b/packages/docs/src/pages/components/autocomplete/Autocomplete.vue
@@ -23,7 +23,7 @@
             </div>
             <p>You can show options by groups</p>
         </Example>
-        
+
         <Example :component="ExKeepFirst" :code="ExKeepFirstCode" title="Keep First">
             <div class="tags has-addons">
                 <span class="tag is-success">Since</span>
@@ -33,7 +33,7 @@
             <p>Additionally, use <code>select-on-click-outside</code> to automatically select the first element when clicking outside of
                 the <code>input</code> element.</p>
         </Example>
-        
+
         <Example :component="ExCustomAsync" :code="ExCustomAsyncCode" title="Async with custom template">
             <p>You can have a custom template by adding a scoped slot to it.</p>
             <p><small>API from <a href="https://www.themoviedb.org" target="_blank">TMDb</a></small>.</p>
@@ -52,6 +52,7 @@
 <script>
     import api from './api/autocomplete'
     import variables from './variables/autocomplete'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -73,7 +74,7 @@
 
     import ExInfiniteScroll from './examples/ExInfiniteScroll'
     import ExInfiniteScrollCode from './examples/ExInfiniteScroll.vue?raw'
-    
+
     import ExKeepFirst from './examples/ExKeepFirst'
     import ExKeepFirstCode from './examples/ExKeepFirst.vue?raw'
 
@@ -82,21 +83,23 @@
             return {
                 api,
                 variables,
-                ExSimple,
+                ...shallowFields({
+                    ExSimple,
+                    ExObjArray,
+                    ExHeader,
+                    ExFooter,
+                    ExCustomAsync,
+                    ExInfiniteScroll,
+                    ExGroups,
+                    ExKeepFirst
+                }),
                 ExSimpleCode,
                 ExObjArrayCode,
-                ExObjArray,
-                ExHeader,
                 ExHeaderCode,
-                ExFooter,
                 ExFooterCode,
                 ExCustomAsyncCode,
-                ExCustomAsync,
-                ExInfiniteScroll,
                 ExInfiniteScrollCode,
-                ExGroups,
                 ExGroupsCode,
-                ExKeepFirst,
                 ExKeepFirstCode
             }
         }

--- a/packages/docs/src/pages/components/breadcrumb/Breadcrumb.vue
+++ b/packages/docs/src/pages/components/breadcrumb/Breadcrumb.vue
@@ -3,7 +3,7 @@
     	<Example :component="ExAlignments" :code="ExAlignmentsCode" title="Alignments"/>
 
     	<Example :component="ExSeparators" :code="ExSeparatorsCode" title="Separators"/>
-    	
+
     	<Example :component="ExSizes" :code="ExSizesCode" title="Sizes"/>
 
         <ApiView :data="api"/>
@@ -14,6 +14,7 @@
 <script>
 	import api from './api/breadcrumb'
     import variables from './variables/breadcrumb'
+    import { shallowFields } from '../../../utils'
 
 	import ExAlignments from './examples/ExAlignments'
     import ExAlignmentsCode from './examples/ExAlignments.vue?raw'
@@ -25,18 +26,20 @@
     import ExSizesCode from './examples/ExSizes.vue?raw'
 
     export default {
-    
+
         name: 'Breadcrumb',
-    
+
         data () {
             return {
             	api,
             	variables,
-            	ExAlignments,
+                ...shallowFields({
+                    ExAlignments,
+                    ExSeparators,
+                    ExSizes
+                }),
             	ExAlignmentsCode,
-            	ExSeparators,
             	ExSeparatorsCode,
-            	ExSizes,
             	ExSizesCode,
             }
         }

--- a/packages/docs/src/pages/components/button/Button.vue
+++ b/packages/docs/src/pages/components/button/Button.vue
@@ -25,6 +25,7 @@
 <script>
     import api from './api/button'
     import variables from './variables/button'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -49,12 +50,14 @@
             return {
                 api,
                 variables,
-                ExSimple,
-                ExTypesStates,
-                ExIcons,
-                ExSizes,
-                ExTags,
-                ExRouter,
+                ...shallowFields({
+                    ExSimple,
+                    ExTypesStates,
+                    ExIcons,
+                    ExSizes,
+                    ExTags,
+                    ExRouter
+                }),
                 ExSimpleCode,
                 ExTypesStatesCode,
                 ExIconsCode,

--- a/packages/docs/src/pages/components/carousel/Carousel.vue
+++ b/packages/docs/src/pages/components/carousel/Carousel.vue
@@ -50,6 +50,7 @@
 <script>
     import api from './api/carousel'
     import variables from './variables/carousel'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExFull from './examples/ExFull'
@@ -79,16 +80,18 @@
             return {
                 api,
                 variables,
-                ExSimple,
-                ExFull,
-                ExArrow,
-                ExIndicator,
-                ExProgress,
-                ExCustomIndicator,
-                ExGallery,
-                ExCarouselList,
-                ExWithCard,
-                ExWithList,
+                ...shallowFields({
+                    ExSimple,
+                    ExFull,
+                    ExArrow,
+                    ExIndicator,
+                    ExProgress,
+                    ExCustomIndicator,
+                    ExGallery,
+                    ExCarouselList,
+                    ExWithCard,
+                    ExWithList
+                }),
                 ExSimpleCode,
                 ExFullCode,
                 ExArrowCode,

--- a/packages/docs/src/pages/components/checkbox/Checkbox.vue
+++ b/packages/docs/src/pages/components/checkbox/Checkbox.vue
@@ -22,6 +22,7 @@
 <script>
     import api from './api/checkbox'
     import variables from './variables/checkbox'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -43,15 +44,17 @@
             return {
                 api,
                 variables,
-                ExSimple,
+                ...shallowFields({
+                    ExSimple,
+                    ExArray,
+                    ExSizes,
+                    ExTypes,
+                    ExCheckboxButton
+                }),
                 ExSimpleCode,
-                ExArray,
                 ExArrayCode,
-                ExSizes,
                 ExSizesCode,
-                ExTypes,
                 ExTypesCode,
-                ExCheckboxButton,
                 ExCheckboxButtonCode
             }
         }

--- a/packages/docs/src/pages/components/clockpicker/Clockpicker.vue
+++ b/packages/docs/src/pages/components/clockpicker/Clockpicker.vue
@@ -17,7 +17,7 @@
         <Example :component="ExColors" :code="ExColorsCode" title="Colors" vertical>
             <p>
                 Clockpicker supports all <code>is-&lt;color&gt;</code> classes from Bulma, including custom colors added at build time.
-                This can be specified in the <code>class</code> property or in the <code>type</code> property. 
+                This can be specified in the <code>class</code> property or in the <code>type</code> property.
                 Inline display is also availble by specifying the <code>inline</code> prop.
             </p>
         </Example>
@@ -28,6 +28,7 @@
 
 <script>
     import api from './api/clockpicker'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -48,15 +49,17 @@
         data() {
             return {
                 api,
-                ExSimple,
+                ...shallowFields({
+                    ExSimple,
+                    ExNonReadonly,
+                    ExRange,
+                    ExFooter,
+                    ExColors
+                }),
                 ExSimpleCode,
-                ExNonReadonly,
                 ExNonReadonlyCode,
-                ExRange,
                 ExRangeCode,
-                ExFooter,
                 ExFooterCode,
-                ExColors,
                 ExColorsCode
             }
         }

--- a/packages/docs/src/pages/components/collapse/Collapse.vue
+++ b/packages/docs/src/pages/components/collapse/Collapse.vue
@@ -16,6 +16,7 @@
 
 <script>
     import api from './api/collapse'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -36,15 +37,17 @@
         data() {
             return {
                 api,
-                ExSimple,
+                ...shallowFields({
+                    ExSimple,
+                    ExPanelTemplate,
+                    ExCardTemplate,
+                    ExPosition,
+                    ExAccordion
+                }),
                 ExSimpleCode,
-                ExPanelTemplate,
                 ExPanelTemplateCode,
-                ExCardTemplate,
                 ExCardTemplateCode,
-                ExPosition,
                 ExPositionCode,
-                ExAccordion,
                 ExAccordionCode
             }
         }

--- a/packages/docs/src/pages/components/colorpicker/Colorpicker.vue
+++ b/packages/docs/src/pages/components/colorpicker/Colorpicker.vue
@@ -18,6 +18,7 @@
 <script>
     import api from './api/colorpicker'
     import variables from './variables/colorpicker'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -39,16 +40,17 @@
             return {
                 api,
                 variables,
-
-                ExSimple,
+                ...shallowFields({
+                    ExSimple,
+                    ExAlpha,
+                    ExRepresentation,
+                    ExFormatter,
+                    ExFields
+                }),
                 ExSimpleCode,
-                ExAlpha,
                 ExAlphaCode,
-                ExRepresentation,
                 ExRepresentationCode,
-                ExFormatter,
                 ExFormatterCode,
-                ExFields,
                 ExFieldsCode
             }
         }

--- a/packages/docs/src/pages/components/datepicker/Datepicker.vue
+++ b/packages/docs/src/pages/components/datepicker/Datepicker.vue
@@ -88,6 +88,7 @@
 <script>
     import api from './api/datepicker'
     import variables from './variables/datepicker'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -133,31 +134,33 @@
             return {
                 api,
                 variables,
-                ExSimple,
+                ...shallowFields({
+                    ExSimple,
+                    ExEditable,
+                    ExRange,
+                    ExFooter,
+                    ExHeader,
+                    ExProgrammatically,
+                    ExTrigger,
+                    ExInline,
+                    ExUnselectable,
+                    ExEvents,
+                    ExMonth,
+                    ExRangeInput,
+                    ExMultipleInput,
+                }),
                 ExSimpleCode,
-                ExEditable,
                 ExEditableCode,
-                ExRange,
                 ExRangeCode,
-                ExFooter,
                 ExFooterCode,
-                ExHeader,
                 ExHeaderCode,
-                ExProgrammatically,
                 ExProgrammaticallyCode,
-                ExTrigger,
                 ExTriggerCode,
-                ExInline,
                 ExInlineCode,
-                ExUnselectable,
                 ExUnselectableCode,
-                ExEvents,
                 ExEventsCode,
-                ExMonth,
                 ExMonthCode,
-                ExRangeInput,
                 ExRangeInputCode,
-                ExMultipleInput,
                 ExMultipleInputCode
             }
         }

--- a/packages/docs/src/pages/components/datetimepicker/Datetimepicker.vue
+++ b/packages/docs/src/pages/components/datetimepicker/Datetimepicker.vue
@@ -28,6 +28,7 @@
 
 <script>
     import api from './api/datetimepicker'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -51,12 +52,14 @@
         data() {
             return {
                 api,
-                ExSimple,
-                ExEditable,
-                ExRange,
-                ExFooter,
-                ExInline,
-                ExGranularity,
+                ...shallowFields({
+                    ExSimple,
+                    ExEditable,
+                    ExRange,
+                    ExFooter,
+                    ExInline,
+                    ExGranularity,
+                }),
                 ExSimpleCode,
                 ExEditableCode,
                 ExRangeCode,

--- a/packages/docs/src/pages/components/dialog/Dialog.vue
+++ b/packages/docs/src/pages/components/dialog/Dialog.vue
@@ -23,6 +23,7 @@
 <script>
     import { preformat } from '@/utils'
     import api from './api/dialog'
+    import { shallowFields } from '../../../utils'
 
     import ExAlertDialog from './examples/ExAlertDialog'
     import ExAlertDialogCode from './examples/ExAlertDialog.vue?raw'
@@ -37,11 +38,13 @@
         data() {
             return {
                 api,
-                ExAlertDialog,
+                ...shallowFields({
+                    ExAlertDialog,
+                    ExConfirmDialog,
+                    ExPromptDialog
+                }),
                 ExAlertDialogCode,
-                ExConfirmDialog,
                 ExConfirmDialogCode,
-                ExPromptDialog,
                 ExPromptDialogCode,
                 outsideVueInstance: `
                 import { DialogProgrammatic as Dialog } from 'buefy'

--- a/packages/docs/src/pages/components/dropdown/Dropdown.vue
+++ b/packages/docs/src/pages/components/dropdown/Dropdown.vue
@@ -43,6 +43,7 @@
 <script>
     import api from './api/dropdown'
     import variables from './variables/dropdown'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -67,17 +68,19 @@
             return {
                 api,
                 variables,
-                ExSimple,
+                ...shallowFields({
+                    ExSimple,
+                    ExContentPosition,
+                    ExHasLinkDisabled,
+                    ExCustomize,
+                    ExCustomizeMultiple,
+                    ExCustomizeScrollable
+                }),
                 ExSimpleCode,
-                ExContentPosition,
                 ExContentPositionCode,
-                ExHasLinkDisabled,
                 ExHasLinkDisabledCode,
-                ExCustomize,
                 ExCustomizeCode,
-                ExCustomizeMultiple,
                 ExCustomizeMultipleCode,
-                ExCustomizeScrollable,
                 ExCustomizeScrollableCode
             }
         }

--- a/packages/docs/src/pages/components/field/Field.vue
+++ b/packages/docs/src/pages/components/field/Field.vue
@@ -100,6 +100,7 @@
 <script>
     import api from './api/field'
     import variables from './variables/field'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -142,18 +143,20 @@
             return {
                 api,
                 variables,
-                ExSimple,
-                ExObjectSyntax,
-                ExAddons,
-                ExGroups,
-                ExGroupExpanded,
-                ExGroupMultiline,
-                ExPositions,
-                ExCombineAddonsGroups,
-                ExHorizontal,
-                ExCustomClass,
-                ExLabelSlot,
-                ExLabelPosition,
+                ...shallowFields({
+                    ExSimple,
+                    ExObjectSyntax,
+                    ExAddons,
+                    ExGroups,
+                    ExGroupExpanded,
+                    ExGroupMultiline,
+                    ExPositions,
+                    ExCombineAddonsGroups,
+                    ExHorizontal,
+                    ExCustomClass,
+                    ExLabelSlot,
+                    ExLabelPosition
+                }),
                 ExSimpleCode,
                 ExObjectSyntaxCode,
                 ExAddonsCode,

--- a/packages/docs/src/pages/components/icon/Icon.vue
+++ b/packages/docs/src/pages/components/icon/Icon.vue
@@ -48,6 +48,7 @@
 <script>
     import api from './api/icon'
     import variables from './variables/icon'
+    import { shallowFields } from '../../../utils'
 
     import ExMdi from './examples/ExMdi'
     import ExMdiCode from './examples/ExMdi.vue?raw'
@@ -66,13 +67,15 @@
             return {
                 api,
                 variables,
-                ExMdi,
-                ExFa,
-                ExObjectSyntax,
+                ...shallowFields({
+                    ExMdi,
+                    ExFa,
+                    ExObjectSyntax,
+                    ExCustom
+                }),
                 ExMdiCode,
                 ExFaCode,
                 ExObjectSyntaxCode,
-                ExCustom,
                 ExCustomCode,
                 usage: `
                 import { library } from '@fortawesome/fontawesome-svg-core';

--- a/packages/docs/src/pages/components/image/Image.vue
+++ b/packages/docs/src/pages/components/image/Image.vue
@@ -49,6 +49,7 @@
 <script>
     import api from './api/image'
     import variables from './variables/image'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -66,15 +67,17 @@
             return {
                 api,
                 variables,
-                ExSimple,
+                ...shallowFields({
+                    ExSimple,
+                    ExWebp,
+                    ExPlaceholder,
+                    ExSrcset,
+                    ExError
+                }),
                 ExSimpleCode,
-                ExWebp,
                 ExWebpCode,
-                ExPlaceholder,
                 ExPlaceholderCode,
-                ExSrcset,
                 ExSrcsetCode,
-                ExError,
                 ExErrorCode
             }
         }

--- a/packages/docs/src/pages/components/input/Input.vue
+++ b/packages/docs/src/pages/components/input/Input.vue
@@ -22,7 +22,7 @@
         </Example>
 
         <Example :component="ExLazy" :code="ExLazyCode" title="Lazy" vertical>
-            <p>You could make the binding lazy, comparable with <code>v-model.lazy</code>, see <a href="https://vuejs.org/v2/guide/forms.html#lazy">.lazy modifier</a>. 
+            <p>You could make the binding lazy, comparable with <code>v-model.lazy</code>, see <a href="https://vuejs.org/v2/guide/forms.html#lazy">.lazy modifier</a>.
             As <code>v-model.lazy</code> won't work with custom components like Buefy, you could use this property.</p>
         </Example>
 
@@ -36,6 +36,7 @@
 <script>
     import api from './api/input'
     import variables from './variables/input'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -66,13 +67,16 @@
             return {
                 api,
                 variables,
-                ExSimple,
-                ExHorizontal,
-                ExTypesStates,
-                ExIcons,
-                ExValidation,
-                ExPassword,
-                ExSizes,
+                ...shallowFields({
+                    ExSimple,
+                    ExHorizontal,
+                    ExTypesStates,
+                    ExIcons,
+                    ExValidation,
+                    ExPassword,
+                    ExSizes,
+                    ExLazy
+                }),
                 ExSimpleCode,
                 ExHorizontalCode,
                 ExTypesStatesCode,
@@ -80,7 +84,6 @@
                 ExValidationCode,
                 ExPasswordCode,
                 ExSizesCode,
-                ExLazy,
                 ExLazyCode
             }
         }

--- a/packages/docs/src/pages/components/loading/Loading.vue
+++ b/packages/docs/src/pages/components/loading/Loading.vue
@@ -28,6 +28,7 @@
 <script>
     import api from './api/loading'
     import variables from './variables/loading'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -43,9 +44,11 @@
             return {
                 api,
                 variables,
-                ExSimple,
-                ExProgrammatically,
-                ExTemplated,
+                ...shallowFields({
+                    ExSimple,
+                    ExProgrammatically,
+                    ExTemplated
+                }),
                 ExSimpleCode,
                 ExProgrammaticallyCode,
                 ExTemplatedCode

--- a/packages/docs/src/pages/components/menu/Menu.vue
+++ b/packages/docs/src/pages/components/menu/Menu.vue
@@ -10,6 +10,7 @@
 <script>
     import api from './api/menu'
     import variables from './variables/menu'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -19,7 +20,9 @@
             return {
                 api,
                 variables,
-                ExSimple,
+                ...shallowFields({
+                    ExSimple
+                }),
                 ExSimpleCode
             }
         }

--- a/packages/docs/src/pages/components/message/Message.vue
+++ b/packages/docs/src/pages/components/message/Message.vue
@@ -32,6 +32,7 @@
 <script>
     import api from './api/message'
     import variables from './variables/message'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -62,14 +63,16 @@
             return {
                 api,
                 variables,
-                ExSimple,
-                ExTypes,
-                ExIcons,
-                ExHeaderless,
-                ExCustomHeader,
-                ExSizes,
-                ExAutoClose,
-                ExAutoCloseWithProgressBar,
+                ...shallowFields({
+                    ExSimple,
+                    ExTypes,
+                    ExIcons,
+                    ExHeaderless,
+                    ExCustomHeader,
+                    ExSizes,
+                    ExAutoClose,
+                    ExAutoCloseWithProgressBar
+                }),
                 ExSimpleCode,
                 ExTypesCode,
                 ExIconsCode,

--- a/packages/docs/src/pages/components/modal/Modal.vue
+++ b/packages/docs/src/pages/components/modal/Modal.vue
@@ -35,6 +35,7 @@
 
     import api from './api/modal'
     import variables from './variables/modal'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -53,10 +54,12 @@
             return {
                 api,
                 variables,
-                ExSimple,
-                ExComponent,
-                ExProgrammatic,
-                ExFullScreen,
+                ...shallowFields({
+                    ExSimple,
+                    ExComponent,
+                    ExProgrammatic,
+                    ExFullScreen
+                }),
                 ExSimpleCode,
                 ExComponentCode,
                 ExProgrammaticCode,

--- a/packages/docs/src/pages/components/navbar/Navbar.vue
+++ b/packages/docs/src/pages/components/navbar/Navbar.vue
@@ -11,16 +11,19 @@
 <script>
     import api from './api/navbar'
     import variables from './variables/navbar'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
-    
+
     export default {
         data() {
             return {
                 api,
                 variables,
-                ExSimple,
+                ...shallowFields({
+                    ExSimple
+                }),
                 ExSimpleCode
             }
         },

--- a/packages/docs/src/pages/components/notification/Notification.vue
+++ b/packages/docs/src/pages/components/notification/Notification.vue
@@ -38,6 +38,7 @@
 
     import api from './api/notification'
     import variables from './variables/notification'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -62,12 +63,14 @@
             return {
                 api,
                 variables,
-                ExSimple,
-                ExTypes,
-                ExIcons,
-                ExAutoClose,
-                ExAutoCloseWithProgressBar,
-                ExProgrammatically,
+                ...shallowFields({
+                    ExSimple,
+                    ExTypes,
+                    ExIcons,
+                    ExAutoClose,
+                    ExAutoCloseWithProgressBar,
+                    ExProgrammatically
+                }),
                 ExSimpleCode,
                 ExTypesCode,
                 ExIconsCode,

--- a/packages/docs/src/pages/components/numberinput/Numberinput.vue
+++ b/packages/docs/src/pages/components/numberinput/Numberinput.vue
@@ -25,6 +25,7 @@
 
 <script>
     import api from './api/numberinput'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -54,17 +55,19 @@
         data() {
             return {
                 api,
-                ExSimple,
-                ExTypes,
-                ExStep,
-                ExAlignment,
-                ExCustomize,
-                ExRange,
-                ExSizes,
+                ...shallowFields({
+                    ExSimple,
+                    ExTypes,
+                    ExStep,
+                    ExAlignment,
+                    ExCustomize,
+                    ExRange,
+                    ExSizes,
+                    ExExpon
+                }),
                 ExSimpleCode,
                 ExTypesCode,
                 ExStepCode,
-                ExExpon,
                 ExExponCode,
                 ExAlignmentCode,
                 ExCustomizeCode,

--- a/packages/docs/src/pages/components/pagination/Pagination.vue
+++ b/packages/docs/src/pages/components/pagination/Pagination.vue
@@ -15,6 +15,7 @@
 <script>
     import api from './api/pagination'
     import variables from './variables/pagination'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -27,9 +28,11 @@
             return {
                 api,
                 variables,
-                ExSimple,
+                ...shallowFields({
+                    ExSimple,
+                    ExSlot
+                }),
                 ExSimpleCode,
-                ExSlot,
                 ExSlotCode
             }
         }

--- a/packages/docs/src/pages/components/progress/Progress.vue
+++ b/packages/docs/src/pages/components/progress/Progress.vue
@@ -27,6 +27,7 @@
 <script>
     import api from './api/progress'
     import variables from './variables/progress'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -54,19 +55,21 @@
             return {
                 api,
                 variables,
-                ExSimple,
-                ExTypes,
-                ExSizes,
-                ExNotRounded,
-                ExValues,
-                ExSlot,
+                ...shallowFields({
+                    ExSimple,
+                    ExTypes,
+                    ExSizes,
+                    ExNotRounded,
+                    ExValues,
+                    ExSlot,
+                    ExBars
+                }),
                 ExSimpleCode,
                 ExTypesCode,
                 ExSizesCode,
                 ExNotRoundedCode,
                 ExValuesCode,
                 ExSlotCode,
-                ExBars,
                 ExBarsCode
             }
         }

--- a/packages/docs/src/pages/components/radio/Radio.vue
+++ b/packages/docs/src/pages/components/radio/Radio.vue
@@ -18,6 +18,7 @@
 <script>
     import api from './api/radio'
     import variables from './variables/radio'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -36,10 +37,12 @@
             return {
                 api,
                 variables,
-                ExSimple,
-                ExSizes,
-                ExTypes,
-                ExRadioButton,
+                ...shallowFields({
+                    ExSimple,
+                    ExSizes,
+                    ExTypes,
+                    ExRadioButton
+                }),
                 ExSimpleCode,
                 ExSizesCode,
                 ExTypesCode,

--- a/packages/docs/src/pages/components/rate/Rate.vue
+++ b/packages/docs/src/pages/components/rate/Rate.vue
@@ -12,6 +12,7 @@
 <script>
     import api from './api/rate'
     import variables from './variables/rate'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -24,8 +25,10 @@
             return {
                 api,
                 variables,
-                ExSimple,
-                ExFull,
+                ...shallowFields({
+                    ExSimple,
+                    ExFull
+                }),
                 ExSimpleCode,
                 ExFullCode
             }

--- a/packages/docs/src/pages/components/select/Select.vue
+++ b/packages/docs/src/pages/components/select/Select.vue
@@ -14,6 +14,7 @@
 
 <script>
     import api from './api/select'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -31,10 +32,12 @@
         data() {
             return {
                 api,
-                ExSimple,
-                ExMultiple,
-                ExIcons,
-                ExSizes,
+                ...shallowFields({
+                    ExSimple,
+                    ExMultiple,
+                    ExIcons,
+                    ExSizes
+                }),
                 ExSimpleCode,
                 ExMultipleCode,
                 ExIconsCode,

--- a/packages/docs/src/pages/components/sidebar/Sidebar.vue
+++ b/packages/docs/src/pages/components/sidebar/Sidebar.vue
@@ -13,20 +13,23 @@
 <script>
     import api from './api/sidebar'
     import variables from './variables/sidebar'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
     import ExStatic from './examples/ExStatic'
     import ExStaticCode from './examples/ExStatic.vue?raw'
-    
+
     export default {
         data() {
             return {
                 api,
                 variables,
-                ExSimple,
+                ...shallowFields({
+                    ExSimple,
+                    ExStatic
+                }),
                 ExSimpleCode,
-                ExStatic,
                 ExStaticCode
             }
         },

--- a/packages/docs/src/pages/components/skeleton/Skeleton.vue
+++ b/packages/docs/src/pages/components/skeleton/Skeleton.vue
@@ -14,6 +14,7 @@
 <script>
     import api from './api/skeleton'
     import variables from './variables/skeleton'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -29,11 +30,13 @@
             return {
                 api,
                 variables,
-                ExSimple,
+                ...shallowFields({
+                    ExSimple,
+                    ExMediaTemplate,
+                    ExCardTemplate
+                }),
                 ExSimpleCode,
-                ExMediaTemplate,
                 ExMediaTemplateCode,
-                ExCardTemplate,
                 ExCardTemplateCode
             }
         }

--- a/packages/docs/src/pages/components/slider/Slider.vue
+++ b/packages/docs/src/pages/components/slider/Slider.vue
@@ -33,6 +33,7 @@
 <script>
     import api from './api/slider'
     import variables from './variables/slider'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -56,21 +57,23 @@
             return {
                 api,
                 variables,
-                ExSimple,
+                ...shallowFields({
+                    ExSimple,
+                    ExSizes,
+                    ExTypes,
+                    ExCustomize,
+                    ExTick,
+                    ExRange,
+                    ExLazy,
+                    ExIndicator
+                }),
                 ExSimpleCode,
-                ExSizes,
                 ExSizesCode,
-                ExTypes,
                 ExTypesCode,
-                ExCustomize,
                 ExCustomizeCode,
-                ExTick,
                 ExTickCode,
-                ExRange,
                 ExRangeCode,
-                ExLazy,
                 ExLazyCode,
-                ExIndicator,
                 ExIndicatorCode
             }
         }

--- a/packages/docs/src/pages/components/snackbar/Snackbar.vue
+++ b/packages/docs/src/pages/components/snackbar/Snackbar.vue
@@ -22,6 +22,7 @@
 
     import api from './api/snackbar'
     import variables from './variables/snackbar'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -31,7 +32,9 @@
             return {
                 api,
                 variables,
-                ExSimple,
+                ...shallowFields({
+                    ExSimple
+                }),
                 ExSimpleCode,
                 outsideVueInstance: `
                 import { SnackbarProgrammatic as Snackbar } from 'buefy'

--- a/packages/docs/src/pages/components/steps/Steps.vue
+++ b/packages/docs/src/pages/components/steps/Steps.vue
@@ -23,6 +23,7 @@
 <script>
     import api from './api/steps'
     import variables from './variables/steps'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -47,17 +48,19 @@
             return {
                 api,
                 variables,
-                ExSimple,
-                ExDynamic,
-                ExIcons,
-                ExSizes,
-                ExTypes,
+                ...shallowFields({
+                    ExSimple,
+                    ExDynamic,
+                    ExIcons,
+                    ExSizes,
+                    ExTypes,
+                    ExVertical
+                }),
                 ExSimpleCode,
                 ExDynamicCode,
                 ExIconsCode,
                 ExSizesCode,
                 ExTypesCode,
-                ExVertical,
                 ExVerticalCode
             }
         }

--- a/packages/docs/src/pages/components/switch/Switch.vue
+++ b/packages/docs/src/pages/components/switch/Switch.vue
@@ -16,6 +16,7 @@
 <script>
     import api from './api/switch'
     import variables from './variables/switch'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -34,10 +35,12 @@
             return {
                 api,
                 variables,
-                ExSimple,
-                ExTypes,
-                ExSizes,
-                ExStyles,
+                ...shallowFields({
+                    ExSimple,
+                    ExTypes,
+                    ExSizes,
+                    ExStyles
+                }),
                 ExSimpleCode,
                 ExTypesCode,
                 ExSizesCode,

--- a/packages/docs/src/pages/components/table/Table.vue
+++ b/packages/docs/src/pages/components/table/Table.vue
@@ -139,6 +139,7 @@
 <script>
     import api from './api/table'
     import variables from './variables/table'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -196,24 +197,26 @@
             return {
                 api,
                 variables,
-                ExSimple,
-                ExSandbox,
-                ExSelection,
-                ExCheckable,
-                ExSearchable,
-                ExSortMultiple,
-                ExPaginationSort,
-                ExDetailedRow,
-                ExCustomDetailedRow,
-                ExRowStatus,
-                ExCustomHeaders,
-                ExSubheadings,
-                ExSticky,
-                ExToggleColumns,
-                ExFooter,
-                ExAsyncData,
+                ...shallowFields({
+                    ExSimple,
+                    ExSandbox,
+                    ExSelection,
+                    ExCheckable,
+                    ExSearchable,
+                    ExSortMultiple,
+                    ExPaginationSort,
+                    ExDetailedRow,
+                    ExCustomDetailedRow,
+                    ExRowStatus,
+                    ExCustomHeaders,
+                    ExSubheadings,
+                    ExSticky,
+                    ExToggleColumns,
+                    ExFooter,
+                    ExAsyncData,
+                    ExDraggableRows
+                }),
                 ExSimpleCode,
-                ExDraggableRows,
                 ExSandboxCode,
                 ExSelectionCode,
                 ExCheckableCode,

--- a/packages/docs/src/pages/components/tabs/Tabs.vue
+++ b/packages/docs/src/pages/components/tabs/Tabs.vue
@@ -38,6 +38,7 @@
 <script>
     import api from './api/tabs'
     import variables from './variables/tabs'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -71,13 +72,17 @@
             return {
                 api,
                 variables,
-                ExSimple,
-                ExDynamic,
-                ExPosition,
-                ExIcons,
-                ExSizes,
-                ExTypes,
-                ExExpanded,
+                ...shallowFields({
+                    ExSimple,
+                    ExDynamic,
+                    ExPosition,
+                    ExIcons,
+                    ExSizes,
+                    ExTypes,
+                    ExExpanded,
+                    ExCustomHeaders,
+                    ExVertical
+                }),
                 ExSimpleCode,
                 ExDynamicCode,
                 ExPositionCode,
@@ -85,9 +90,7 @@
                 ExSizesCode,
                 ExTypesCode,
                 ExExpandedCode,
-                ExCustomHeaders,
                 ExCustomHeadersCode,
-                ExVertical,
                 ExVerticalCode
             }
         }

--- a/packages/docs/src/pages/components/tag/Tag.vue
+++ b/packages/docs/src/pages/components/tag/Tag.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <Example :component="ExSimple" :code="ExSimpleCode" vertical/>
-        
+
         <Example :component="ExIcon" :code="ExIconCode" vertical/>
 
         <p class="content">Closable tags have a button that can be focused, it emits a <code>close</code> event when clicked or when <b>delete</b> key is pressed.</p>
@@ -30,6 +30,7 @@
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
+    import { shallowFields } from '../../../utils'
 
     import ExIcon from './examples/ExIcon'
     import ExIconCode from './examples/ExIcon.vue?raw'
@@ -53,13 +54,15 @@
         data() {
             return {
                 api,
-                ExSimple,
-                ExIcon,
-                ExClosable,
-                ExTaglist,
-                ExTaglistAttached,
-                ExFieldCombine,
-                ExSizes,
+                ...shallowFields({
+                    ExSimple,
+                    ExIcon,
+                    ExClosable,
+                    ExTaglist,
+                    ExTaglistAttached,
+                    ExFieldCombine,
+                    ExSizes
+                }),
                 ExSimpleCode,
                 ExIconCode,
                 ExClosableCode,

--- a/packages/docs/src/pages/components/taginput/Taginput.vue
+++ b/packages/docs/src/pages/components/taginput/Taginput.vue
@@ -52,6 +52,7 @@
 <script>
     import api from './api/taginput'
     import variables from './variables/taginput'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -88,16 +89,18 @@
             return {
                 api,
                 variables,
-                ExSimple,
-                ExAutocomplete,
-                ExTemplatedAutocomplete,
-                ExSelected,
-                ExLimit,
-                ExState,
-                ExType,
-                ExSize,
-                ExModifier,
-                ExValidation,
+                ...shallowFields({
+                    ExSimple,
+                    ExAutocomplete,
+                    ExTemplatedAutocomplete,
+                    ExSelected,
+                    ExLimit,
+                    ExState,
+                    ExType,
+                    ExSize,
+                    ExModifier,
+                    ExValidation
+                }),
                 ExSimpleCode,
                 ExAutocompleteCode,
                 ExTemplatedAutocompleteCode,

--- a/packages/docs/src/pages/components/timepicker/Timepicker.vue
+++ b/packages/docs/src/pages/components/timepicker/Timepicker.vue
@@ -28,6 +28,7 @@
 
 <script>
     import api from './api/timepicker'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -51,12 +52,14 @@
         data() {
             return {
                 api,
-                ExSimple,
-                ExEditable,
-                ExRange,
-                ExFooter,
-                ExGranularity,
-                ExInline,
+                ...shallowFields({
+                    ExSimple,
+                    ExEditable,
+                    ExRange,
+                    ExFooter,
+                    ExGranularity,
+                    ExInline
+                }),
                 ExSimpleCode,
                 ExEditableCode,
                 ExGranularityCode,

--- a/packages/docs/src/pages/components/toast/Toast.vue
+++ b/packages/docs/src/pages/components/toast/Toast.vue
@@ -21,6 +21,7 @@
     import { preformat } from '@/utils'
     import api from './api/toast'
     import variables from './variables/toast'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -30,7 +31,9 @@
             return {
                 api,
                 variables,
-                ExSimple,
+                ...shallowFields({
+                    ExSimple
+                }),
                 ExSimpleCode,
                 outsideVueInstance: `
                 import { ToastProgrammatic as Toast } from 'buefy'

--- a/packages/docs/src/pages/components/tooltip/Tooltip.vue
+++ b/packages/docs/src/pages/components/tooltip/Tooltip.vue
@@ -26,6 +26,7 @@
 <script>
     import api from './api/tooltip'
     import variables from './variables/tooltip'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -47,11 +48,13 @@
             return {
                 api,
                 variables,
-                ExSimple,
-                ExStyles,
-                ExMultilined,
-                ExToggle,
-                ExCustom,
+                ...shallowFields({
+                    ExSimple,
+                    ExStyles,
+                    ExMultilined,
+                    ExToggle,
+                    ExCustom
+                }),
                 ExSimpleCode,
                 ExStylesCode,
                 ExMultilinedCode,

--- a/packages/docs/src/pages/components/upload/Upload.vue
+++ b/packages/docs/src/pages/components/upload/Upload.vue
@@ -3,11 +3,11 @@
         <Example :component="ExSimple" :code="ExSimpleCode" vertical/>
 
         <Example :component="ExDragDrop" :code="ExDragDropCode" title="Drag and drop" vertical/>
-        
+
         <Example :component="ExExpanded" :code="ExExpandedCode" title="Expanded" vertical/>
-        
+
         <Example :component="ExRounded" :code="ExRoundedCode" title="Rounded" vertical/>
-        
+
         <Example :component="ExValidation" :code="ExValidationCode" title="Validation" vertical/>
 
         <ApiView :data="api"/>
@@ -16,6 +16,7 @@
 
 <script>
     import api from './api/upload'
+    import { shallowFields } from '../../../utils'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from './examples/ExSimple.vue?raw'
@@ -25,7 +26,7 @@
 
     import ExExpanded from './examples/ExExpanded'
     import ExExpandedCode from './examples/ExExpanded.vue?raw'
-    
+
     import ExRounded from './examples/ExRounded'
     import ExRoundedCode from './examples/ExRounded.vue?raw'
 
@@ -37,15 +38,17 @@
         data() {
             return {
                 api,
-                ExSimple,
-                ExDragDrop,
-                ExExpanded,
+                ...shallowFields({
+                    ExSimple,
+                    ExDragDrop,
+                    ExExpanded,
+                    ExRounded,
+                    ExValidation
+                }),
                 ExSimpleCode,
                 ExDragDropCode,
                 ExExpandedCode,
-                ExRounded,
                 ExRoundedCode,
-                ExValidation,
                 ExValidationCode,
             }
         }

--- a/packages/docs/src/utils/index.js
+++ b/packages/docs/src/utils/index.js
@@ -1,3 +1,5 @@
+import { shallowRef } from 'vue'
+
 export function preformat(text) {
     if (!text) return
 
@@ -15,4 +17,12 @@ export function preformat(text) {
     newText = newText.join('\r\n')
 
     return newText
+}
+
+export function shallowFields(fields) {
+    for(const key in fields) {
+        fields[key] = shallowRef(fields[key])
+    }
+
+    return fields
 }


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes: #168 
```
[Warning] [Vue warn]: Vue received a Component which was made a reactive object. 
This can lead to unnecessary performance overhead, and should be avoided by marking the component with `markRaw` or using `shallowRef` instead of `ref`. 
````

## Proposed Changes

- Remove the warning on every component page located on the Buefy-next [documentation website](https://v3.buefy.org) by:
   - Creating a helper function (`shallowFields`) to shallow ref the components being passed to the Example.vue component.
   - Implement the `shallowFields()` function on every component page that passes a component to the Example.vue component's prop.
   
###  Completion of Changes to All UI Components
- [x] Breadcrumb
- [x] Button
- [x] Carousel
- [x] Collapse
- [x] Dialog
- [x] Dropdown
 - [x] Icon
- [x] Image
- [x] Loading
- [x] Menu
- [x] Message
- [x] Modal
- [x] Navbar
- [x] Notification
- [x] Pagination
- [x] Progress
- [x] Skeleton
- [x] Sidebar
- [x] Snackbar
- [x] Steps
- [x] Table
- [x] Tabs
- [x] Tag
- [x] Toast
- [x] Tooltip

**Form Controls**
   - [x] Autocomplete
   - [x] Checkbox
   - [x] Clockpicker
   - [x] Colorpicker
   - [x] Datepicker
   - [x] Datetimepicker
   - [x] Field
   - [x] Input
   - [x] Numberinput
   - [x] Radio
   - [x] Rate
   - [x] Select
   - [x] Slider
   - [x] Switch
   - [x] Taginput
   - [x] Timepicker
   - [x] Upload 

### Testing Method
I confirmed that the warning above was no longer present by opening my dev tools, selecting the console tab, and filtering the message by the keyword `reactive`. 



##### Steps to Perform the Test
1. Run the dev server by typing `cd .\packages\docs\` and then `npm run dev` into your console.
2. Open your preferred web browser.
3. Open the dev tools by pressing F12.
4. Select the Console tab.
5. Filter the Console by the keyword `reactive`.
> ![image](https://github.com/ntohq/buefy-next/assets/11604664/4a70db20-2b3a-4636-b41d-c17045962487)
6. Navigate to each component page without closing the dev tools.
7. Check the Console tab to confirm that the warnings are no longer present.
   - If a warning does show, confirm that you completed step 5.
   - If step 5 is still set in the Console tab, please share a screenshot of that component in your review.

### Notes for Reviewing
1. Please confirm that I have passed all components to shallow fields for each Buefy component page.
2. Perform the above test.
