### PR TITLE
Fix: [Input] Vue Compat: deprecation INSTANCE_ATTRS_CLASS_STYLE (#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Buefy Changelog
 
+## buefy-next unreleased
+
+### New features
+
+* `Input` introduces a new prop `compat-fallthrough`, which determines whether `class`, `style`, and `id` attributes are applied to the root `<div>`, or either of `<input>` or `<textarea>` element.
+  If `true`, they are applied to the root `<div>` element, which is compatible with Vue 2.
+  The default value can be controlled by `defaultInputCompatFallthrough` config option (`true` by default).
+  [#16](https://github.com/ntohq/buefy-next/issues/16)
+
 ## buefy-next
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * `Input` introduces a new prop `compat-fallthrough`, which determines whether `class`, `style`, and `id` attributes are applied to the root `<div>`, or either of `<input>` or `<textarea>` element.
   If `true`, they are applied to the root `<div>` element, which is compatible with Vue 2.
-  The default value can be controlled by `defaultInputCompatFallthrough` config option (`true` by default).
+  The default value can be controlled by `defaultCompatFallthrough` config option (`true` by default).
   [#16](https://github.com/ntohq/buefy-next/issues/16)
 
 ## buefy-next

--- a/packages/buefy-next/src/components/clockpicker/__snapshots__/Clockpicker.spec.js.snap
+++ b/packages/buefy-next/src/components/clockpicker/__snapshots__/Clockpicker.spec.js.snap
@@ -4,7 +4,7 @@ exports[`BClockpicker render correctly 1`] = `
 <div class="b-clockpicker control is-primary">
   <div class="dropdown dropdown-menu-animation is-mobile-modal">
     <div tabindex="0" class="dropdown-trigger" aria-haspopup="true">
-      <b-input-stub type="text" lazy="false" passwordreveal="false" iconclickable="false" hascounter="true" customclass="" iconrightclickable="false" autocomplete="off" loading="false" readonly="" rounded="false" use-html5-validation="true"></b-input-stub>
+      <b-input-stub type="text" lazy="false" passwordreveal="false" iconclickable="false" hascounter="true" customclass="" iconrightclickable="false" compatfallthrough="true" autocomplete="off" loading="false" readonly="" rounded="false" use-html5-validation="true"></b-input-stub>
     </div>
     <transition-stub name="fade" appear="false" persisted="false" css="true">
       <div class="background" aria-hidden="true" style="display: none;"></div>

--- a/packages/buefy-next/src/components/colorpicker/__snapshots__/Colorpicker.spec.js.snap
+++ b/packages/buefy-next/src/components/colorpicker/__snapshots__/Colorpicker.spec.js.snap
@@ -33,7 +33,7 @@ exports[`BColorpicker render correctly 1`] = `
                       <div class="field-body">
                         <div class="field">
                           <!--v-if-->
-                          <b-input-stub modelvalue="0" type="number" lazy="false" passwordreveal="false" iconclickable="false" hascounter="true" customclass="" iconrightclickable="false" modelmodifiers="[object Object]" size="is-small" aria-label="Red"></b-input-stub>
+                          <b-input-stub modelvalue="0" type="number" lazy="false" passwordreveal="false" iconclickable="false" hascounter="true" customclass="" iconrightclickable="false" compatfallthrough="true" modelmodifiers="[object Object]" size="is-small" aria-label="Red"></b-input-stub>
                           <!--v-if-->
                         </div>
                       </div>
@@ -44,7 +44,7 @@ exports[`BColorpicker render correctly 1`] = `
                       <div class="field-body">
                         <div class="field">
                           <!--v-if-->
-                          <b-input-stub modelvalue="0" type="number" lazy="false" passwordreveal="false" iconclickable="false" hascounter="true" customclass="" iconrightclickable="false" modelmodifiers="[object Object]" size="is-small" aria-label="Green"></b-input-stub>
+                          <b-input-stub modelvalue="0" type="number" lazy="false" passwordreveal="false" iconclickable="false" hascounter="true" customclass="" iconrightclickable="false" compatfallthrough="true" modelmodifiers="[object Object]" size="is-small" aria-label="Green"></b-input-stub>
                           <!--v-if-->
                         </div>
                       </div>
@@ -55,7 +55,7 @@ exports[`BColorpicker render correctly 1`] = `
                       <div class="field-body">
                         <div class="field">
                           <!--v-if-->
-                          <b-input-stub modelvalue="0" type="number" lazy="false" passwordreveal="false" iconclickable="false" hascounter="true" customclass="" iconrightclickable="false" modelmodifiers="[object Object]" size="is-small" aria-label="Blue"></b-input-stub>
+                          <b-input-stub modelvalue="0" type="number" lazy="false" passwordreveal="false" iconclickable="false" hascounter="true" customclass="" iconrightclickable="false" compatfallthrough="true" modelmodifiers="[object Object]" size="is-small" aria-label="Blue"></b-input-stub>
                           <!--v-if-->
                         </div>
                       </div>

--- a/packages/buefy-next/src/components/datepicker/__snapshots__/Datepicker.spec.js.snap
+++ b/packages/buefy-next/src/components/datepicker/__snapshots__/Datepicker.spec.js.snap
@@ -4,7 +4,7 @@ exports[`BDatepicker render correctly 1`] = `
 <div class="datepicker control">
   <div class="dropdown dropdown-menu-animation is-mobile-modal">
     <div tabindex="-1" class="dropdown-trigger" aria-haspopup="true">
-      <b-input-stub type="text" lazy="false" passwordreveal="false" iconclickable="false" hascounter="true" customclass="" iconrightclickable="false" autocomplete="off" rounded="false" loading="false" readonly="" use-html5-validation="false"></b-input-stub>
+      <b-input-stub type="text" lazy="false" passwordreveal="false" iconclickable="false" hascounter="true" customclass="" iconrightclickable="false" compatfallthrough="true" autocomplete="off" rounded="false" loading="false" readonly="" use-html5-validation="false"></b-input-stub>
     </div>
     <transition-stub name="fade" appear="false" persisted="false" css="true">
       <div class="background" aria-hidden="true" style="display: none;"></div>

--- a/packages/buefy-next/src/components/input/Input.spec.js
+++ b/packages/buefy-next/src/components/input/Input.spec.js
@@ -287,4 +287,47 @@ describe('BInput', () => {
             })
         })
     })
+
+    describe('with fallthrough attributes', () => {
+        const attrs = {
+            class: 'fallthrough-class',
+            style: 'font-size: 2rem;',
+            id: 'fallthrough-id'
+        }
+
+        it('should bind class, style, and id to the root div if compatFallthrough is true (default)', () => {
+            const wrapper = shallowMount(BInput, { attrs })
+            const root = wrapper.find('div.control')
+            expect(root.classes(attrs.class)).toBe(true)
+            expect(root.attributes('style')).toBe(attrs.style)
+            expect(root.attributes('id')).toBe(attrs.id)
+        })
+
+        it('should bind class, style, and id to the input element if compatFallthrough is false', () => {
+            const wrapper = shallowMount(BInput, {
+                attrs,
+                props: {
+                    compatFallthrough: false
+                }
+            })
+            const input = wrapper.find('input')
+            expect(input.classes(attrs.class)).toBe(true)
+            expect(input.attributes('style')).toBe(attrs.style)
+            expect(input.attributes('id')).toBe(attrs.id)
+        })
+
+        it('should bind class, style, and id to the textarea element if compatFallthrough is false', () => {
+            const wrapper = shallowMount(BInput, {
+                attrs,
+                props: {
+                    compatFallthrough: false,
+                    type: 'textarea'
+                }
+            })
+            const textarea = wrapper.find('textarea')
+            expect(textarea.classes(attrs.class)).toBe(true)
+            expect(textarea.attributes('style')).toBe(attrs.style)
+            expect(textarea.attributes('id')).toBe(attrs.id)
+        })
+    })
 })

--- a/packages/buefy-next/src/components/input/Input.vue
+++ b/packages/buefy-next/src/components/input/Input.vue
@@ -104,7 +104,7 @@ export default {
         // if true, `class`, `style`, and `id` are applied to the root <div>
         compatFallthrough: {
             type: Boolean,
-            default: () => config.defaultInputCompatFallthrough
+            default: () => config.defaultCompatFallthrough
         }
     },
     emits: [

--- a/packages/buefy-next/src/components/input/Input.vue
+++ b/packages/buefy-next/src/components/input/Input.vue
@@ -2,6 +2,7 @@
     <div
         class="control"
         :class="rootClasses"
+        v-bind="rootAttrs"
     >
         <input
             v-if="type !== 'textarea'"
@@ -12,7 +13,7 @@
             :autocomplete="newAutocomplete"
             :maxlength="maxlength"
             :value="computedValue"
-            v-bind="$attrs"
+            v-bind="inputAttrs"
             @input="onInput"
             @change="onChange"
             @blur="onBlur"
@@ -26,7 +27,7 @@
             :class="[inputClasses, customClass]"
             :maxlength="maxlength"
             :value="computedValue"
-            v-bind="$attrs"
+            v-bind="inputAttrs"
             @input="onInput"
             @change="onChange"
             @blur="onBlur"
@@ -99,7 +100,12 @@ export default {
         },
         iconRight: String,
         iconRightClickable: Boolean,
-        iconRightType: String
+        iconRightType: String,
+        // if true, `class`, `style`, and `id` are applied to the root <div>
+        compatFallthrough: {
+            type: Boolean,
+            default: () => config.defaultInputCompatFallthrough
+        }
     },
     emits: [
         'icon-click',
@@ -127,6 +133,23 @@ export default {
                 this.$emit('update:modelValue', value)
             }
         },
+        rootAttrs() {
+            return this.compatFallthrough
+                ? {
+                    // class is included in `rootClasses`
+                    style: this.$attrs.style,
+                    id: this.$attrs.id
+                }
+                : {}
+        },
+        inputAttrs() {
+            if (this.compatFallthrough) {
+                const { class: _1, style: _2, id: _3, ...rest } = this.$attrs
+                return rest
+            } else {
+                return this.$attrs
+            }
+        },
         rootClasses() {
             return [
                 this.iconPosition,
@@ -135,7 +158,8 @@ export default {
                     'is-expanded': this.expanded,
                     'is-loading': this.loading,
                     'is-clearfix': !this.hasMessage
-                }
+                },
+                this.compatFallthrough ? this.$attrs.class : undefined
             ]
         },
         inputClasses() {

--- a/packages/buefy-next/src/components/timepicker/__snapshots__/Timepicker.spec.js.snap
+++ b/packages/buefy-next/src/components/timepicker/__snapshots__/Timepicker.spec.js.snap
@@ -4,7 +4,7 @@ exports[`BTimepicker render correctly 1`] = `
 <div class="timepicker control">
   <div class="dropdown dropdown-menu-animation is-mobile-modal">
     <div tabindex="0" class="dropdown-trigger" aria-haspopup="true">
-      <b-input-stub type="text" lazy="false" passwordreveal="false" iconclickable="false" hascounter="true" customclass="" iconrightclickable="false" autocomplete="off" loading="false" readonly="" rounded="false" use-html5-validation="true"></b-input-stub>
+      <b-input-stub type="text" lazy="false" passwordreveal="false" iconclickable="false" hascounter="true" customclass="" iconrightclickable="false" compatfallthrough="true" autocomplete="off" loading="false" readonly="" rounded="false" use-html5-validation="true"></b-input-stub>
     </div>
     <transition-stub name="fade" appear="false" persisted="false" css="true">
       <div class="background" aria-hidden="true" style="display: none;"></div>

--- a/packages/buefy-next/src/utils/config.js
+++ b/packages/buefy-next/src/utils/config.js
@@ -35,6 +35,11 @@ let config = {
     defaultTimepickerMobileModal: true,
     defaultNoticeQueue: true,
     defaultInputHasCounter: true,
+    /**
+     * Whether `class`, `style`, and `id` are applied to the root `<div>`
+     * element in `Input` by default.
+     */
+    defaultInputCompatFallthrough: true,
     defaultTaginputHasCounter: true,
     defaultUseHtml5Validation: true,
     defaultDropdownMobileModal: true,

--- a/packages/buefy-next/src/utils/config.js
+++ b/packages/buefy-next/src/utils/config.js
@@ -36,10 +36,11 @@ let config = {
     defaultNoticeQueue: true,
     defaultInputHasCounter: true,
     /**
-     * Whether `class`, `style`, and `id` are applied to the root `<div>`
-     * element in `Input` by default.
+     * Whether `class`, `style`, and `id` are applied to the root element in
+     * components that are affected by Vue 3 change in fallthgourh beahvior.
+     * See: https://github.com/ntohq/buefy-next/issues/16
      */
-    defaultInputCompatFallthrough: true,
+    defaultCompatFallthrough: true,
     defaultTaginputHasCounter: true,
     defaultUseHtml5Validation: true,
     defaultDropdownMobileModal: true,

--- a/packages/docs/src/pages/components/input/api/input.js
+++ b/packages/docs/src/pages/components/input/api/input.js
@@ -114,6 +114,13 @@ export default [
                 default: '—'
             },
             {
+                name: '<code>compat-fallthrough</code>',
+                description: 'Whether <code>class</code>, <code>style</code>, and <code>id</code> attributes are applied to the root &lt;div&gt;, or either of &lt;input&gt; or &lt;textarea&gt; element. If <code>true</code>, they are applied to the root &lt;div&gt; element, which is compatible with Vue 2.',
+                type: 'Boolean',
+                values: '-',
+                default: '<code>true</code>. Can be changed via <code>defaultInputCompatFallthrough</code> config option.'
+            },
+            {
                 name: 'Any native attribute',
                 description: '—',
                 type: '—',

--- a/packages/docs/src/pages/components/input/api/input.js
+++ b/packages/docs/src/pages/components/input/api/input.js
@@ -118,7 +118,7 @@ export default [
                 description: 'Whether <code>class</code>, <code>style</code>, and <code>id</code> attributes are applied to the root &lt;div&gt;, or either of &lt;input&gt; or &lt;textarea&gt; element. If <code>true</code>, they are applied to the root &lt;div&gt; element, which is compatible with Vue 2.',
                 type: 'Boolean',
                 values: '-',
-                default: '<code>true</code>. Can be changed via <code>defaultInputCompatFallthrough</code> config option.'
+                default: '<code>true</code>. Can be changed via <code>defaultCompatFallthrough</code> config option.'
             },
             {
                 name: 'Any native attribute',


### PR DESCRIPTION
Related issue
- #16

## Proposed Changes

- Introduce a new prop `compat-fallthrough` to `Input`, which determines if `class`, `style`, and `id` attributes are applied to the root `<div>` element instead of the underlying `<input>` or `<textarea>` element. If `true`, they are applied to the root `<div>` element, which is compatible with Vue 2.
- Introduce a new config option `defaultCompatFallthrough` to provide the default value for the `compat-fallthrough` prop
- Add new tests for the `compat-fallthrough` prop
- Explain the `compat-fallthrough` prop in the `Input` doc page
- Add the introduction of the `compat-fallthrough` prop as a new feature to `CHANGELOG`
- Refresh test snapshots affected by the introduction of the `compat-fallthrough` prop