### PR TITLE
Fix: [Autocomplete] Vue Compat: deprecation INSTANCE_ATTRS_CLASS_STYLE (#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@
 
 ### New features
 
-* `Autocomplete` introduces a new prop `compat-fallthrough`, which determines whether `class`, `style`, and `id` attributes are applied to the root `<div>` element or the underlying `<b-input>`.
+* `Autocomplete` introduces a new prop `compat-fallthrough`, which determines whether the `class`, `style`, and `id` attributes are applied to the root `<div>` element or the underlying `<b-input>`.
   If `true`, they are applied to the root `<div>` element, which is compatible with Buefy for Vue 2.
-  The default value can be controlled by `defaultCompatFallthrough` config option (`true` by default).
+  The default value can be controlled by the `defaultCompatFallthrough` config option (`true` by default).
   [#16](https://github.com/ntohq/buefy-next/issues/16)
-* `Input` introduces a new prop `compat-fallthrough`, which determines whether `class`, `style`, and `id` attributes are applied to the root `<div>`, or either of `<input>` or `<textarea>` element.
+* `Input` introduces a new prop `compat-fallthrough`, which determines whether the `class`, `style`, and `id` attributes are applied to the root `<div>`, or either of `<input>` or `<textarea>` element.
   If `true`, they are applied to the root `<div>` element, which is compatible with Buefy for Vue 2.
-  The default value can be controlled by `defaultCompatFallthrough` config option (`true` by default).
+  The default value can be controlled by the `defaultCompatFallthrough` config option (`true` by default).
   [#16](https://github.com/ntohq/buefy-next/issues/16)
 
 ## buefy-next

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@
 
 ### New features
 
+* `Autocomplete` introduces a new prop `compat-fallthrough`, which determines whether `class`, `style`, and `id` attributes are applied to the root `<div>` element or the underlying `<b-input>`.
+  If `true`, they are applied to the root `<div>` element, which is compatible with Buefy for Vue 2.
+  The default value can be controlled by `defaultCompatFallthrough` config option (`true` by default).
+  [#16](https://github.com/ntohq/buefy-next/issues/16)
 * `Input` introduces a new prop `compat-fallthrough`, which determines whether `class`, `style`, and `id` attributes are applied to the root `<div>`, or either of `<input>` or `<textarea>` element.
-  If `true`, they are applied to the root `<div>` element, which is compatible with Vue 2.
+  If `true`, they are applied to the root `<div>` element, which is compatible with Buefy for Vue 2.
   The default value can be controlled by `defaultCompatFallthrough` config option (`true` by default).
   [#16](https://github.com/ntohq/buefy-next/issues/16)
 

--- a/packages/buefy-next/src/components/autocomplete/Autocomplete.spec.js
+++ b/packages/buefy-next/src/components/autocomplete/Autocomplete.spec.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils'
+import { mount, shallowMount } from '@vue/test-utils'
 import BAutocomplete from '@components/autocomplete/Autocomplete'
 
 const findStringsStartingWith = (array, value) =>
@@ -395,5 +395,34 @@ describe('BAutocomplete', () => {
 
         expect(active).toBeTruthy()
         expect(active[0]).toEqual([true])
+    })
+
+    describe('with fallthrough attributes', () => {
+        const attrs = {
+            class: 'fallthrough-class',
+            style: 'font-size: 2rem;',
+            id: 'fallthrough-id'
+        }
+
+        it('should bind class, style, and id to the root div if compatFallthrough is true (default)', async () => {
+            const wrapper = shallowMount(BAutocomplete, { attrs })
+            const root = wrapper.find('div.autocomplete.control')
+            expect(root.classes(attrs.class)).toBe(true)
+            expect(root.attributes('style')).toBe(attrs.style)
+            expect(root.attributes('id')).toBe(attrs.id)
+        })
+
+        it('should bind class, style, and id to the input if compatFallthrough is false', async () => {
+            const wrapper = shallowMount(BAutocomplete, {
+                attrs,
+                props: {
+                    compatFallthrough: false
+                }
+            })
+            const input = wrapper.findComponent({ ref: 'input' })
+            expect(input.classes(attrs.class)).toBe(true)
+            expect(input.attributes('style')).toBe(attrs.style)
+            expect(input.attributes('id')).toBe(attrs.id)
+        })
     })
 })

--- a/packages/buefy-next/src/components/autocomplete/Autocomplete.vue
+++ b/packages/buefy-next/src/components/autocomplete/Autocomplete.vue
@@ -1,5 +1,9 @@
 <template>
-    <div class="autocomplete control" :class="{ 'is-expanded': expanded }">
+    <div
+        class="autocomplete control"
+        :class="{ 'is-expanded': expanded }"
+        v-bind="rootAttrs"
+    >
         <b-input
             v-model="newValue"
             ref="input"
@@ -15,7 +19,7 @@
             :autocomplete="newAutocomplete"
             :use-html5-validation="false"
             :aria-autocomplete="ariaAutocomplete"
-            v-bind="$attrs"
+            v-bind="inputAttrs"
             @update:model-value="onInput"
             @focus="focused"
             @blur="onBlur"
@@ -107,6 +111,7 @@
 </template>
 
 <script>
+import config from '../../utils/config'
 import {
     getValueByPath,
     removeElement,
@@ -161,7 +166,11 @@ export default {
             default: () => ['Tab', 'Enter']
         },
         selectableHeader: Boolean,
-        selectableFooter: Boolean
+        selectableFooter: Boolean,
+        compatFallthrough: {
+            type: Boolean,
+            default: () => config.defaultCompatFallthrough
+        }
     },
     emits: [
         'active',
@@ -313,6 +322,23 @@ export default {
             return this.iconRightClickable
         },
 
+        rootAttrs() {
+            return this.compatFallthrough
+                ? {
+                    class: this.$attrs.class,
+                    style: this.$attrs.style,
+                    id: this.$attrs.id
+                }
+                : {}
+        },
+        inputAttrs() {
+            if (this.compatFallthrough) {
+                const { style: _1, class: _2, id: _3, ...rest } = this.$attrs
+                return rest
+            } else {
+                return this.$attrs
+            }
+        },
         contentStyle() {
             return {
                 maxHeight: toCssWidth(this.maxHeight)

--- a/packages/buefy-next/src/components/taginput/__snapshots__/Taginput.spec.js.snap
+++ b/packages/buefy-next/src/components/taginput/__snapshots__/Taginput.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`BTaginput render correctly 1`] = `
 <div class="taginput control">
   <div class="taginput-container is-focusable">
-    <b-autocomplete-stub modelvalue="" data="" field="value" keepfirst="false" clearonselect="false" openonfocus="false" checkinfinitescroll="false" keepopen="true" selectonclickoutside="false" clearable="false" dropdownposition="auto" iconrightclickable="false" appendtobody="false" type="text" confirmkeys=",,Tab,Enter" selectableheader="false" selectablefooter="false" has-counter="false" loading="false" use-html5-validation="true"></b-autocomplete-stub>
+    <b-autocomplete-stub modelvalue="" data="" field="value" keepfirst="false" clearonselect="false" openonfocus="false" checkinfinitescroll="false" keepopen="true" selectonclickoutside="false" clearable="false" dropdownposition="auto" iconrightclickable="false" appendtobody="false" type="text" confirmkeys=",,Tab,Enter" selectableheader="false" selectablefooter="false" compatfallthrough="true" has-counter="false" loading="false" use-html5-validation="true"></b-autocomplete-stub>
   </div>
   <!--v-if-->
 </div>

--- a/packages/docs/src/pages/components/autocomplete/api/autocomplete.js
+++ b/packages/docs/src/pages/components/autocomplete/api/autocomplete.js
@@ -177,6 +177,13 @@ export default [
                 default: '<code>false</code>'
             },
             {
+                name: '<code>compat-fallthrough</code>',
+                description: 'Whether <code>class</code>, <code>style</code>, and <code>id</code> attributes are applied to the root &lt;div&gt; element or the underlying &lt;b-input&gt;. If <code>true</code>, they are applied to the root &lt;div&gt; element, which is compatible with Vue 2.',
+                type: 'Boolean',
+                values: '-',
+                default: '<code>true</code>. Can be changed via <code>defaultCompatFallthrough</code> config option.'
+            },
+            {
                 name: 'Any native attribute',
                 description: '—',
                 type: '—',


### PR DESCRIPTION
Related issue:
- #16

## Proposed Changes

- Introduce a new prop `compat-fallthrough` to `Autocomplete`, which determines if `class`, `style`, and `id` attributes are applied to the root `<div>` element instead of the underlying `b-input` component. If `true`, they are applied to root `<div>` element, which is compatible with Buefy for Vue 2.
- Add new tests for `compat-fallthrough`
- Explain the `compat-fallthrough` prop in the `Autocomplete` doc page
- Add the introduction of the `compat-fallthrough` prop of `Autocomplete` to `CHANGELOG` as a new feature
- Refresh a test snapshot affected by the introduction of the `compat-fallthrough` prop