### PR TITLE
Fix: BTabs does not work in SSR due to window access (#187) and related issue (#194)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@
   If `true`, they are applied to the root `<div>` element, which is compatible with Vue 2.
   The default value can be controlled by `defaultCompatFallthrough` config option (`true` by default).
   [#16](https://github.com/ntohq/buefy-next/issues/16)
-* `CarouselItem`, `StepItem`, and `TabItem` introduce a new prop `order`, which determines the order of each tab item.
-  By default, the order of each tab item is determined by the sequence in which each tab item is mounted.
-  If any tab item is unmounted and mounted again, the order may be changed (**BREAKING CHANGE**).
-  You have to give explicit `order` if you want to maintain the order of items consistent.
+* `CarouselItem`, `StepItem`, and `TabItem` introduce a new prop `order`, which determines the order of each child item.
+  By default, the order of each child item is determined by the sequence in which each child item is mounted.
+  If any child item is unmounted and mounted again, the order may be changed (**BREAKING CHANGE**).
+  You have to give explicit `order` if you want to maintain the order of child items consistent.
 
 ## buefy-next
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   If `true`, they are applied to the root `<div>` element, which is compatible with Vue 2.
   The default value can be controlled by `defaultCompatFallthrough` config option (`true` by default).
   [#16](https://github.com/ntohq/buefy-next/issues/16)
+* `CarouselItem`, `StepItem`, and `TabItem` introduce a new prop `order`, which determine the ordering of items.
+  By default, the order is determined according to when items are mounted in sequence.
+  If any item is unmounted and mounted again, the order may be changed (**BREAKING CHANGE**).
+  You have to give explicit `order` if you want to maintain the order of items consistent.
 
 ## buefy-next
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@
   If `true`, they are applied to the root `<div>` element, which is compatible with Vue 2.
   The default value can be controlled by `defaultCompatFallthrough` config option (`true` by default).
   [#16](https://github.com/ntohq/buefy-next/issues/16)
-* `CarouselItem`, `StepItem`, and `TabItem` introduce a new prop `order`, which determine the ordering of items.
-  By default, the order is determined according to when items are mounted in sequence.
-  If any item is unmounted and mounted again, the order may be changed (**BREAKING CHANGE**).
+* `CarouselItem`, `StepItem`, and `TabItem` introduce a new prop `order`, which determines the order of each tab item.
+  By default, the order of each tab item is determined by the sequence in which each tab item is mounted.
+  If any tab item is unmounted and mounted again, the order may be changed (**BREAKING CHANGE**).
   You have to give explicit `order` if you want to maintain the order of items consistent.
 
 ## buefy-next

--- a/packages/buefy-next/src/components/carousel/Carousel.vue
+++ b/packages/buefy-next/src/components/carousel/Carousel.vue
@@ -228,6 +228,12 @@ export default {
         },
         hasNext() {
             return this.repeat || this.activeChild < this.childItems.length - 1
+        },
+
+        // internal index of the active child
+        activeChildIndex() {
+            const item = this.sortedItems[this.activeChild]
+            return item != null ? item.index : undefined
         }
     },
     watch: {

--- a/packages/buefy-next/src/components/carousel/Carousel.vue
+++ b/packages/buefy-next/src/components/carousel/Carousel.vue
@@ -230,7 +230,6 @@ export default {
             return this.repeat || this.activeChild < this.childItems.length - 1
         },
 
-        // internal index of the active child
         activeChildIndex() {
             const item = this.sortedItems[this.activeChild]
             return item != null ? item.index : undefined

--- a/packages/buefy-next/src/components/carousel/CarouselItem.spec.js
+++ b/packages/buefy-next/src/components/carousel/CarouselItem.spec.js
@@ -11,7 +11,7 @@ const WrapperComp = {
         <BCarousel ref="carousel" :animated="animated">
             <BCarouselItem value="item1"/>
             <BCarouselItem ref="testItem" value="item2"/>
-            <BCarouselItem value="item3"/>
+            <BCarouselItem ref="testItem2" value="item3"/>
         </BCarousel>`,
     props: {
         // to indirectly change BCarousel's animated prop
@@ -55,5 +55,45 @@ describe('BCarouselItem', () => {
         await wrapperParent.setProps({ animated: 'fade' })
         wrapperCarousel.vm.changeActive(0)
         expect(wrapper.vm.transition).toBe('fade')
+    })
+
+    it('update active state', () => {
+        expect(wrapper.vm.isActive).toBe(false)
+
+        wrapperCarousel.vm.changeActive(1)
+        expect(wrapper.vm.isActive).toBe(true)
+
+        wrapperCarousel.vm.changeActive(2)
+        expect(wrapper.vm.isActive).toBe(false)
+    })
+
+    describe('with explicit order', () => {
+        let wrapper
+        let wrapperCarousel
+        let wrapperTestItem
+
+        beforeEach(() => {
+            wrapper = mount({
+                template: `
+                    <BCarousel ref="carousel">
+                        <BCarouselItem ref="testItem" :order="2" />
+                        <BCarouselItem :order="1" />
+                        <BCarouselItem :order="3" />
+                    </BCarousel>`,
+                components: { BCarousel, BCarouselItem }
+            })
+            wrapperCarousel = wrapper.findComponent({ ref: 'carousel' })
+            wrapperTestItem = wrapper.findComponent({ ref: 'testItem' })
+        })
+
+        it('update active state', () => {
+            expect(wrapperTestItem.vm.isActive).toBe(false)
+
+            wrapperCarousel.vm.changeActive(1)
+            expect(wrapperTestItem.vm.isActive).toBe(true)
+
+            wrapperCarousel.vm.changeActive(2)
+            expect(wrapperTestItem.vm.isActive).toBe(false)
+        })
     })
 })

--- a/packages/buefy-next/src/components/carousel/CarouselItem.vue
+++ b/packages/buefy-next/src/components/carousel/CarouselItem.vue
@@ -28,7 +28,7 @@ export default {
             }
         },
         isActive() {
-            return this.parent.activeChild === this.index
+            return this.parent.activeChildIndex === this.index
         }
     }
 }

--- a/packages/buefy-next/src/components/carousel/__snapshots__/CarouselItem.spec.js.snap
+++ b/packages/buefy-next/src/components/carousel/__snapshots__/CarouselItem.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BCarouselItem render correctly 1`] = `
-<transition-stub name="slide-next" appear="false" persisted="true" css="true" value="item2">
+<transition-stub name="slide-next" appear="false" persisted="true" css="true">
   <div class="carousel-item" style="display: none;"></div>
 </transition-stub>
 `;

--- a/packages/buefy-next/src/components/dropdown/Dropdown.vue
+++ b/packages/buefy-next/src/components/dropdown/Dropdown.vue
@@ -56,16 +56,21 @@
 import trapFocus from '../../directives/trapFocus'
 import config from '../../utils/config'
 import { removeElement, createAbsoluteElement, isCustomElement, toCssWidth } from '../../utils/helpers'
-import ProviderParentMixin from '../../utils/ProviderParentMixin'
 
 const DEFAULT_CLOSE_OPTIONS = ['escape', 'outside']
+
+export const DROPDOWN_INJECTION_KEY = Symbol('bdropdown')
 
 export default {
     name: 'BDropdown',
     directives: {
         trapFocus
     },
-    mixins: [ProviderParentMixin('dropdown')],
+    provide() {
+        return {
+            [DROPDOWN_INJECTION_KEY]: this
+        }
+    },
     props: {
         modelValue: {
             type: [String, Number, Boolean, Object, Array, Function],

--- a/packages/buefy-next/src/components/dropdown/DropdownItem.spec.js
+++ b/packages/buefy-next/src/components/dropdown/DropdownItem.spec.js
@@ -1,4 +1,5 @@
 import { shallowMount } from '@vue/test-utils'
+import { DROPDOWN_INJECTION_KEY } from '@components/dropdown/Dropdown'
 import BDropdownItem from '@components/dropdown/DropdownItem'
 
 let wrapper
@@ -15,7 +16,7 @@ describe('BDropdownItem', () => {
         wrapper = shallowMount(BDropdownItem, {
             global: {
                 provide: {
-                    bdropdown: parent
+                    [DROPDOWN_INJECTION_KEY]: parent
                 }
             }
         })

--- a/packages/buefy-next/src/components/dropdown/DropdownItem.vue
+++ b/packages/buefy-next/src/components/dropdown/DropdownItem.vue
@@ -22,11 +22,16 @@
 </template>
 
 <script>
-import InjectedChildMixin from '../../utils/InjectedChildMixin'
+import { DROPDOWN_INJECTION_KEY } from './Dropdown.vue'
 
 export default {
     name: 'BDropdownItem',
-    mixins: [InjectedChildMixin('dropdown')],
+    inject: {
+        parent: {
+            from: DROPDOWN_INJECTION_KEY,
+            default: undefined
+        }
+    },
     props: {
         value: {
             type: [String, Number, Boolean, Object, Array, Function],

--- a/packages/buefy-next/src/components/progress/Progress.vue
+++ b/packages/buefy-next/src/components/progress/Progress.vue
@@ -22,11 +22,16 @@
 
 <script>
 import config from '../../utils/config'
-import ProviderParentMixin from '../../utils/ProviderParentMixin'
+
+export const PROGRESS_INJECTION_KEY = Symbol('bprogress')
 
 export default {
     name: 'BProgress',
-    mixins: [ProviderParentMixin('progress')],
+    provide() {
+        return {
+            [PROGRESS_INJECTION_KEY]: this
+        }
+    },
     props: {
         type: {
             type: [String, Object],

--- a/packages/buefy-next/src/components/progress/ProgressBar.spec.js
+++ b/packages/buefy-next/src/components/progress/ProgressBar.spec.js
@@ -1,18 +1,28 @@
 import { mount } from '@vue/test-utils'
+import { PROGRESS_INJECTION_KEY } from '@components/progress/Progress'
 import BProgressBar from '@components/progress/ProgressBar'
-import ProviderParentMixin from '../../utils/ProviderParentMixin'
 
 let wrapper
 const BProgress = {
-    mixins: [ProviderParentMixin('progress')],
-    template: '<div><slot /></div>'
+    template: '<div><slot /></div>',
+    provide() {
+        return {
+            [PROGRESS_INJECTION_KEY]: this
+        }
+    },
+    data() {
+        return { max: 100 }
+    }
 }
 
 describe('BProgressBar', () => {
     beforeEach(() => {
         wrapper = mount(BProgress, {
             slots: {
-                default: BProgressBar
+                default: '<BProgressBar :value="20" />'
+            },
+            global: {
+                components: { BProgressBar }
             }
         }).findComponent(BProgressBar)
     })
@@ -24,5 +34,9 @@ describe('BProgressBar', () => {
 
     it('render correctly', () => {
         expect(wrapper.html()).toMatchSnapshot()
+    })
+
+    it('should calculate bar width', () => {
+        expect(wrapper.vm.barWidth).toBe('20%')
     })
 })

--- a/packages/buefy-next/src/components/progress/ProgressBar.vue
+++ b/packages/buefy-next/src/components/progress/ProgressBar.vue
@@ -18,11 +18,16 @@
 </template>
 
 <script>
-import InjectedChildMixin from '../../utils/InjectedChildMixin'
+import { PROGRESS_INJECTION_KEY } from './Progress.vue'
 
 export default {
     name: 'BProgressBar',
-    mixins: [InjectedChildMixin('progress')],
+    inject: {
+        parent: {
+            from: PROGRESS_INJECTION_KEY,
+            default: undefined
+        }
+    },
     props: {
         type: {
             type: [String, Object],

--- a/packages/buefy-next/src/components/progress/__snapshots__/ProgressBar.spec.js.snap
+++ b/packages/buefy-next/src/components/progress/__snapshots__/ProgressBar.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BProgressBar render correctly 1`] = `
-<div class="progress-bar" role="progressbar" aria-valuemin="0">
+<div class="progress-bar" role="progressbar" aria-valuenow="20" aria-valuemax="100" aria-valuemin="0" style="width: 20%;">
   <!--v-if-->
 </div>
 `;

--- a/packages/buefy-next/src/components/steps/StepItem.spec.js
+++ b/packages/buefy-next/src/components/steps/StepItem.spec.js
@@ -8,7 +8,7 @@ const WrapperComp = {
     // values must be specified to make the snapshot reproducible
     // I took the values from the legacy snapshot.
     template: `
-        <BSteps>
+        <BSteps ref="steps">
             <BStepItem value="14" />
             <BStepItem value="16" ref="testItem"/>
             <BStepItem value="18" :visible="false"/>
@@ -19,8 +19,12 @@ const WrapperComp = {
 }
 
 describe('BStepItem', () => {
+    let wrapperSteps
+
     beforeEach(() => {
-        wrapper = mount(WrapperComp).findComponent({ ref: 'testItem' })
+        const root = mount(WrapperComp)
+        wrapperSteps = root.findComponent({ ref: 'steps' })
+        wrapper = root.findComponent({ ref: 'testItem' })
     })
 
     it('is called', () => {
@@ -54,5 +58,52 @@ describe('BStepItem', () => {
 
     it('doesn\'t mount when it has no parent', () => {
         expect(() => mount(BStepItem)).toThrow(/You should wrap/)
+    })
+
+    it('should update active state', () => {
+        expect(wrapper.vm.isActive).toBe(false)
+
+        wrapperSteps.vm.next()
+        expect(wrapper.vm.isActive).toBe(true)
+
+        wrapperSteps.vm.prev()
+        expect(wrapper.vm.isActive).toBe(false)
+    })
+
+    describe('with explicit order', () => {
+        let wrapperSteps
+        let wrapperTestItem
+
+        beforeEach(() => {
+            const wrapper = mount({
+                template: `
+                    <BSteps ref="steps">
+                        <BStepItem ref="testItem" :order="2" />
+                        <BStepItem :order="1" />
+                        <BStepItem :order="3" />
+                    </BSteps>`,
+                components: {
+                    BSteps, BStepItem
+                }
+            })
+            wrapperSteps = wrapper.findComponent({ ref: 'steps' })
+            wrapperTestItem = wrapper.findComponent({ ref: 'testItem' })
+        })
+
+        it('should update active state', () => {
+            expect(wrapperTestItem.vm.isActive).toBe(false)
+
+            wrapperSteps.vm.next()
+            expect(wrapperTestItem.vm.isActive).toBe(true)
+
+            wrapperSteps.vm.next()
+            expect(wrapperTestItem.vm.isActive).toBe(false)
+
+            wrapperSteps.vm.prev()
+            expect(wrapperTestItem.vm.isActive).toBe(true)
+
+            wrapperSteps.vm.prev()
+            expect(wrapperTestItem.vm.isActive).toBe(false)
+        })
     })
 })

--- a/packages/buefy-next/src/components/steps/Steps.vue
+++ b/packages/buefy-next/src/components/steps/Steps.vue
@@ -4,7 +4,7 @@
             <ul class="step-items">
                 <li
                     v-for="childItem in items"
-                    :key="childItem.value"
+                    :key="childItem.uniqueValue"
                     v-show="childItem.visible"
                     class="step-item"
                     :class="[childItem.type || type, childItem.headerClass, {
@@ -137,7 +137,8 @@ export default {
     computed: {
         // Override mixin implementation to always have a value
         activeItem() {
-            return this.childItems.filter((i) => i.value === this.activeId)[0] || this.items[0]
+            return this.childItems.filter((i) => i.uniqueValue === this.activeId)[0] ||
+                this.items[0]
         },
         wrapperClasses() {
             return [
@@ -245,7 +246,7 @@ export default {
          */
         prev() {
             if (this.hasPrev) {
-                this.activeId = this.prevItem.value
+                this.activeId = this.prevItem.uniqueValue
             }
         },
 
@@ -254,7 +255,7 @@ export default {
          */
         next() {
             if (this.hasNext) {
-                this.activeId = this.nextItem.value
+                this.activeId = this.nextItem.uniqueValue
             }
         }
     }

--- a/packages/buefy-next/src/components/tabs/TabItem.spec.js
+++ b/packages/buefy-next/src/components/tabs/TabItem.spec.js
@@ -12,7 +12,7 @@ const WrapperComp = {
         }
     },
     template: `
-        <BTabs>
+        <BTabs ref="tabs">
             <BTabItem v-if="show1" ref="firstItem" value="tab1"/>
             <BTabItem ref="testItem" value="tab2"/>
             <BTabItem value="tab3" :visible="false"/>
@@ -72,6 +72,24 @@ describe('BTabItem', () => {
 
         wrapper.vm.deactivate(0)
         expect(wrapper.vm.transitionName).toBe('slide-next')
+    })
+
+    it('should update active state', async () => {
+        const wrapperFirstItem = wrapperParent.findComponent({ ref: 'firstItem' })
+        // we need `<a>` elements corresponding to individual tabs
+        const firstTabLink = wrapperParent.find(`#${wrapperFirstItem.vm.uniqueValue}-label`)
+        const secondTabLink = wrapperParent.find(`#${wrapper.vm.uniqueValue}-label`)
+
+        expect(wrapperFirstItem.vm.isActive).toBe(true)
+        expect(wrapper.vm.isActive).toBe(false)
+
+        await secondTabLink.trigger('click')
+        expect(wrapperFirstItem.vm.isActive).toBe(false)
+        expect(wrapper.vm.isActive).toBe(true)
+
+        await firstTabLink.trigger('click')
+        expect(wrapperFirstItem.vm.isActive).toBe(true)
+        expect(wrapper.vm.isActive).toBe(false)
     })
 
     it('doesn\'t mount when it has no parent', () => {
@@ -148,5 +166,33 @@ describe('BTabItem', () => {
 
         expect(wrapper.findComponent(BTabs).vm.items.length).toBe(2)
         expect(wrapper.findComponent({ ref: 'item2' }).vm.isActive).toBeTruthy()
+    })
+
+    describe('with explicit order', () => {
+        it('should assign consistent index when tab is added after removal', async () => {
+            const wrapper = mount({
+                template: `
+                    <BTabs ref="tabs">
+                        <BTabItem v-if="show1" ref="firstItem" :order="1" />
+                        <BTabItem :order="2" />
+                        <BTabItem :order="3" />
+                    </BTabs>`,
+                props: {
+                    show1: {
+                        type: Boolean,
+                        default: true
+                    }
+                },
+                components: { BTabs, BTabItem }
+            })
+
+            const firstItem = wrapper.findComponent({ ref: 'firstItem' })
+            expect(firstItem.vm.index).toBe(1)
+            await wrapper.setProps({ show1: false })
+            await wrapper.setProps({ show1: true })
+
+            const firstItem2 = wrapper.findComponent({ ref: 'firstItem' })
+            expect(firstItem2.vm.index).toBe(1)
+        })
     })
 })

--- a/packages/buefy-next/src/components/tabs/TabItem.spec.js
+++ b/packages/buefy-next/src/components/tabs/TabItem.spec.js
@@ -76,7 +76,8 @@ describe('BTabItem', () => {
 
     it('should update active state', async () => {
         const wrapperFirstItem = wrapperParent.findComponent({ ref: 'firstItem' })
-        // we need `<a>` elements corresponding to individual tabs
+        // we need `<a>` elements corresponding to individual tab components to
+        // activate them with 'click'
         const firstTabLink = wrapperParent.find(`#${wrapperFirstItem.vm.uniqueValue}-label`)
         const secondTabLink = wrapperParent.find(`#${wrapper.vm.uniqueValue}-label`)
 

--- a/packages/buefy-next/src/components/tabs/Tabs.vue
+++ b/packages/buefy-next/src/components/tabs/Tabs.vue
@@ -12,12 +12,12 @@
             >
                 <li
                     v-for="childItem in items"
-                    :key="childItem.value"
+                    :key="childItem.uniqueValue"
                     v-show="childItem.visible"
                     :class="[ childItem.headerClass, { 'is-active': childItem.isActive,
                                                        'is-disabled': childItem.disabled }]"
                     role="tab"
-                    :aria-controls="`${childItem.value}-content`"
+                    :aria-controls="`${childItem.uniqueValue}-content`"
                     :aria-selected="`${childItem.isActive}`"
                 >
                     <b-slot-component
@@ -26,7 +26,7 @@
                         :component="childItem"
                         name="header"
                         tag="a"
-                        :id="`${childItem.value}-label`"
+                        :id="`${childItem.uniqueValue}-label`"
                         :tabindex="childItem.isActive ? 0 : -1"
                         @focus="currentFocus = childItem.index"
                         @click="childClick(childItem)"
@@ -35,7 +35,7 @@
                     <a
                         :ref="`tabLink${childItem.index}`"
                         v-else
-                        :id="`${childItem.value}-label`"
+                        :id="`${childItem.uniqueValue}-label`"
                         :tabindex="childItem.isActive ? 0 : -1"
                         @focus="currentFocus = childItem.index"
                         @click="childClick(childItem)"

--- a/packages/buefy-next/src/utils/InjectedChildMixin.js
+++ b/packages/buefy-next/src/utils/InjectedChildMixin.js
@@ -18,9 +18,10 @@ export default (parentItemName, flags = 0) => {
             }
         },
         computed: {
-            // parent uses this to identify the child in a collection.
-            // bound to `value` if `value` is non-null,
-            // otherwise to `uid` internal field
+            // `ProviderParentMixin` uses `uniqueValue` computed value to
+            // identify the child in its `childItems` collection.
+            // so the value must be unique among all the siblings.
+            // falls back to the `uid` internal field to ensure uniqueness.
             uniqueValue() {
                 return this.value != null ? this.value : this.$.uid
             }

--- a/packages/buefy-next/src/utils/InjectedChildMixin.js
+++ b/packages/buefy-next/src/utils/InjectedChildMixin.js
@@ -9,6 +9,22 @@ export const Optional = optional
 export default (parentItemName, flags = 0) => {
     const mixin = {
         inject: { parent: { from: 'b' + parentItemName, default: false } },
+        props: {
+            // if `value` is non-null, it must be unique among all the siblings.
+            // see `uniqueValue`
+            value: {
+                type: String,
+                default: null
+            }
+        },
+        computed: {
+            // parent uses this to identify the child in a collection.
+            // bound to `value` if `value` is non-null,
+            // otherwise to `uid` internal field
+            uniqueValue() {
+                return this.value != null ? this.value : this.$.uid
+            }
+        },
         created() {
             if (!this.parent) {
                 if (!hasFlag(flags, optional)) {
@@ -33,6 +49,7 @@ export default (parentItemName, flags = 0) => {
         // incomplete dynamic indexing is still available if any child is never
         // unmounted; e.g., not switched with `v-if`
         mixin.props = {
+            ...mixin.props,
             order: {
                 type: Number,
                 required: false
@@ -44,6 +61,7 @@ export default (parentItemName, flags = 0) => {
             }
         }
         mixin.computed = {
+            ...mixin.computed,
             index() {
                 return this.order != null ? this.order : this.dynamicIndex
             }

--- a/packages/buefy-next/src/utils/ProviderParentMixin.js
+++ b/packages/buefy-next/src/utils/ProviderParentMixin.js
@@ -35,7 +35,7 @@ export default (itemName, flags = 0) => {
                 this.childItems.push(item)
             },
             _unregisterItem(item) {
-                this.childItems = this.childItems.filter((i) => i.value !== item.value)
+                this.childItems = this.childItems.filter((i) => i.uniqueValue !== item.uniqueValue)
             }
         }
 

--- a/packages/buefy-next/src/utils/TabbedChildMixin.js
+++ b/packages/buefy-next/src/utils/TabbedChildMixin.js
@@ -1,7 +1,6 @@
 import { h as createElement, Transition, vShow, withDirectives } from 'vue'
 
 import InjectedChildMixin, { Sorted } from './InjectedChildMixin'
-import { makeUniqueId } from './make-unique-id'
 
 export default (parentCmp) => ({
     mixins: [InjectedChildMixin(parentCmp, Sorted)],
@@ -12,10 +11,6 @@ export default (parentCmp) => ({
         visible: {
             type: Boolean,
             default: true
-        },
-        value: {
-            type: String,
-            default() { return makeUniqueId() }
         },
         headerClass: {
             type: [String, Array, Object],
@@ -68,9 +63,9 @@ export default (parentCmp) => ({
                     // https://github.com/buefy/buefy/issues/3272
                     class: this.elementClass,
                     role: this.elementRole,
-                    id: `${this.value}-content`,
+                    id: `${this.uniqueValue}-content`,
                     'aria-labelledby': this.elementRole
-                        ? `${this.value}-label`
+                        ? `${this.uniqueValue}-label`
                         : null,
                     tabindex: this.isActive ? 0 : -1
                 },

--- a/packages/buefy-next/src/utils/TabbedMixin.js
+++ b/packages/buefy-next/src/utils/TabbedMixin.js
@@ -44,7 +44,7 @@ export default (cmp) => ({
         if (typeof this.modelValue === 'number') {
             // Backward compatibility: converts the index value to an id
             const value = bound(this.modelValue, 0, this.items.length - 1)
-            this.activeId = this.items[value].value
+            this.activeId = this.items[value].uniqueValue
         } else {
             this.activeId = this.modelValue
         }
@@ -55,7 +55,7 @@ export default (cmp) => ({
                 ? this.items[0]
                 : (this.activeId === null
                     ? null
-                    : this.childItems.find((i) => i.value === this.activeId))
+                    : this.childItems.find((i) => i.uniqueValue === this.activeId))
         },
         items() {
             return this.sortedItems
@@ -69,7 +69,7 @@ export default (cmp) => ({
             if (typeof value === 'number') {
                 // Backward compatibility: converts the index value to an id
                 value = bound(value, 0, this.items.length - 1)
-                this.activeId = this.items[value].value
+                this.activeId = this.items[value].uniqueValue
             } else {
                 this.activeId = value
             }
@@ -79,7 +79,7 @@ export default (cmp) => ({
          */
         activeId(val, oldValue) {
             const oldTab = oldValue !== undefined && oldValue !== null
-                ? this.childItems.find((i) => i.value === oldValue)
+                ? this.childItems.find((i) => i.uniqueValue === oldValue)
                 : null
 
             if (oldTab && this.activeItem) {
@@ -88,7 +88,7 @@ export default (cmp) => ({
             }
 
             val = this.activeItem
-                ? (typeof this.modelValue === 'number' ? this.items.indexOf(this.activeItem) : this.activeItem.value)
+                ? (typeof this.modelValue === 'number' ? this.items.indexOf(this.activeItem) : this.activeItem.uniqueValue)
                 : undefined
 
             if (val !== this.modelValue) {
@@ -101,7 +101,7 @@ export default (cmp) => ({
         * Child click listener, emit input event and change active child.
         */
         childClick(child) {
-            this.activeId = child.value
+            this.activeId = child.uniqueValue
         },
 
         getNextItemIdx(fromIdx, skipDisabled = false) {

--- a/packages/buefy-next/src/utils/make-unique-id.js
+++ b/packages/buefy-next/src/utils/make-unique-id.js
@@ -1,5 +1,0 @@
-export function makeUniqueId() {
-    const values = new Uint8Array(12)
-    window.crypto.getRandomValues(values)
-    return Array.prototype.map.call(values, (v) => v.toString(16)).join('')
-}

--- a/packages/docs/src/pages/components/carousel/Carousel.vue
+++ b/packages/docs/src/pages/components/carousel/Carousel.vue
@@ -9,7 +9,9 @@
 
         <Example :component="ExSimple" :code="ExSimpleCode" paddingless vertical />
 
-        <Example title="Custom" :component="ExFull" :code="ExFullCode" paddingless />
+        <Example title="Custom" :component="ExFull" :code="ExFullCode" paddingless>
+          This example uses <code>order</code> to maintain the consitent order while the number of items may change.
+        </Example>
 
         <Example title="Arrow" :component="ExArrow" :code="ExArrowCode" paddingless />
 

--- a/packages/docs/src/pages/components/carousel/api/carousel.js
+++ b/packages/docs/src/pages/components/carousel/api/carousel.js
@@ -240,7 +240,16 @@ export default [
         ]
     },
     {
-      title: 'Item',
+        title: 'Item',
+        props: [
+            {
+                name: '<code>order</code>',
+                description: 'Order of the item. <code>Carousel</code> sorts the items in ascending order of this value. By default, the order is determined according to when items are mounted in sequence. You have to give an explicit value if you want to keep the ordering when the number of items in <code>Carousel</code> may vary.',
+                type: 'Number',
+                values: '-',
+                default: '-'
+            }
+        ],
         events: [
             {
                 name: '<code>click</code>',

--- a/packages/docs/src/pages/components/carousel/examples/ExFull.vue
+++ b/packages/docs/src/pages/components/carousel/examples/ExFull.vue
@@ -18,10 +18,18 @@
                 <div class="control">
                     <b-switch v-model="repeat" :disabled="!autoPlay">Repeat</b-switch>
                 </div>
+                <div class="control">
+                    <b-switch
+                        :model-value="carousels[3].isHidden"
+                        @update:model-value="carousels[3].isHidden = !carousels[3].isHidden"
+                    >
+                        Hide Slide 4
+                    </b-switch>
+                </div>
             </b-field>
             <b-field grouped group-multiline>
                 <b-field label="Value">
-                    <b-numberinput v-model="carousel" min="0" :max="carousels.length - 1" controls-position="compact"/>
+                    <b-numberinput v-model="carousel" min="0" :max="visibleCarousels.length - 1" controls-position="compact"/>
                 </b-field>
                 <b-field label="Interval">
                     <b-numberinput v-model="interval" min="0" controls-position="compact" step="1000" :disabled="!autoPlay"/>
@@ -59,7 +67,11 @@
             :interval="interval"
             :repeat="repeat"
             @change="info($event)">
-            <b-carousel-item v-for="(carousel, i) in carousels" :key="i">
+            <b-carousel-item
+                v-for="(carousel, i) in visibleCarousels"
+                :key="carousel.order"
+                :order="i"
+            >
                 <section :class="`hero is-medium is-${carousel.color} is-bold`">
                     <div class="hero-body has-text-centered">
                         <h1 class="title">{{carousel.title}}</h1>
@@ -89,10 +101,15 @@ export default {
                 { title: 'Slide 1', color: 'dark' },
                 { title: 'Slide 2', color: 'primary' },
                 { title: 'Slide 3', color: 'info' },
-                { title: 'Slide 4', color: 'success' },
+                { title: 'Slide 4', color: 'success', isHidden: false },
                 { title: 'Slide 5', color: 'warning' },
                 { title: 'Slide 6', color: 'danger' }
             ]
+        }
+    },
+    computed: {
+        visibleCarousels() {
+            return this.carousels.filter(carousel => !carousel.isHidden)
         }
     },
     methods: {

--- a/packages/docs/src/pages/components/steps/Steps.vue
+++ b/packages/docs/src/pages/components/steps/Steps.vue
@@ -4,7 +4,10 @@
 
         <Example :component="ExDynamic" :code="ExDynamicCode" title="Dynamic">
             <p>Items can be created / modified / deleted and will always keep the defined order.</p>
-            <p>You can also use <code>v-if</code> to show (or not) a Step Item.</p>
+            <p>
+              You can also use <code>v-if</code> to show (or not) a Step Item.
+              In this case, you have to specify <code>order</code> to maintain the consistent order.
+            </p>
         </Example>
 
         <Example :component="ExIcons" :code="ExIconsCode" title="Icons"/>

--- a/packages/docs/src/pages/components/steps/api/steps.js
+++ b/packages/docs/src/pages/components/steps/api/steps.js
@@ -226,6 +226,13 @@ export default [
                 type: 'String, Array, Object',
                 values: '-',
                 default: '-'
+            },
+            {
+                name: '<code>order</code>',
+                description: 'The order of the step. <code>Steps</code> sorts the steps in ascending order of this value. By default, the order is determined according to when steps are mounted in sequence. You have to give an explicit value if you want to keep the ordering when the number of steps in <code>Steps</code> may vary.',
+                type: 'Number',
+                values: '-',
+                default: '-'
             }
         ],
         slots: [

--- a/packages/docs/src/pages/components/tabs/Tabs.vue
+++ b/packages/docs/src/pages/components/tabs/Tabs.vue
@@ -4,7 +4,10 @@
 
         <Example :component="ExDynamic" :code="ExDynamicCode" title="Dynamic">
             <p>Items can be created / modified / deleted and will always keep the defined order.</p>
-            <p>You can also use <code>v-if</code> to show (or not) a Tab Item.</p>
+            <p>
+              You can also use <code>v-if</code> to show (or not) a Tab Item.
+              In this case, you have to specify <code>order</code> to maintain the consistent order.
+            </p>
         </Example>
 
         <Example :component="ExPosition" :code="ExPositionCode" title="Position"/>

--- a/packages/docs/src/pages/components/tabs/api/tabs.js
+++ b/packages/docs/src/pages/components/tabs/api/tabs.js
@@ -139,6 +139,13 @@ export default [
                 type: 'String, Array, Object',
                 values: '-',
                 default: '-'
+            },
+            {
+                name: '<code>order</code>',
+                description: 'Order of the tab. <code>Tabs</code> sorts the tabs in ascending order of this value. By default, the order is determined according to when tabs are mounted in sequence. You have to give an explicit value if you want to keep the ordering when the number of tabs in <code>Tabs</code> may vary.',
+                type: 'Number',
+                values: '-',
+                default: '-'
             }
         ],
         slots: [

--- a/packages/docs/src/utils/index.js
+++ b/packages/docs/src/utils/index.js
@@ -20,7 +20,7 @@ export function preformat(text) {
 }
 
 export function shallowFields(fields) {
-    for(const key in fields) {
+    for (const key in fields) {
         fields[key] = shallowRef(fields[key])
     }
 


### PR DESCRIPTION
Fixes #
- fixes #187
- fixes #194

## Proposed Changes

- Stop generating a random ID for `value` prop of `TabItem` because it does not work in Server Side Rendering (SSR). Instead, we no longer directly access `value` but use a new computed value `uniqueValue`, which falls back to `this.$.uid` (Vue's internal unique ID)
- Add `value` and `uniqueValue` to `InjectedChidMixin` to fix not only `Tabs` but also `Carousels`. `Carousels` had an issue that its children (`CarouselItem`s) cannot be removed after mounted.
- Remove `packages/buefy-next/src/utils/make-unique-id.js` because we no longer depend on random IDs
- Stop mixing in `ProviderParentMixin` to `Dropdown` because it does not use any functionalities of `ProviderParentMixin`. Also stop mixing in `InjectedChildMixin` to `DropdownItem`.
- Stop mixing in `ProviderParentMixin` to `Progress` because it does not use any functionalities of `ProviderParentMixin`. Also stop mixing in `InjectedChildMinin` to `ProgressBar`.

The following changes are not directly related to the issues but shared among the updated components:
- Add test cases for `order` prop of `CarouselItem`, `StepItem`, and `TabItem`
- Add explanation of `order` prop of `CarouselItem`, `StepItem`, and `TabItem` to `docs`
- Update `CHANGELOG` to include `order` prop of `CarouselItem`, `StepItem`, and `TabItem` as a new feature

A fix of a minor lint error is also included.