### PR TITLE
Fix [NavbarDropdown]: Vue Compat: deprecation INSTANCE_ATTRS_CLASS_STYLE (#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 
   * `NavbarDropdown`:
 
-    TBD
+    If `compat-fallthrough` is `true`, the attributes fall through to the root `<div>` element, otherwise to the underlying tag.
 
   * `Numberinput`:
 

--- a/packages/buefy-next/src/components/navbar/NavbarDropdown.spec.js
+++ b/packages/buefy-next/src/components/navbar/NavbarDropdown.spec.js
@@ -32,4 +32,51 @@ describe('BNavbarDropdown', () => {
         wrapper.vm.closeMenu()
         expect(wrapper.vm.newActive).toBeFalsy()
     })
+
+    describe('with fallthrough attributes', () => {
+        const attrs = {
+            class: 'fallthrough-class',
+            style: 'font-size: 2rem;',
+            id: 'fallthrough-id'
+        }
+
+        it('should apply class, style, and id to the root <div> element if compatFallthrough is true (default)', () => {
+            const wrapper = shallowMount(BNavbarDropdown, {
+                attrs,
+                props: {
+                    tag: 'a'
+                }
+            })
+
+            const root = wrapper.find('div.navbar-item')
+            expect(root.classes(attrs.class)).toBe(true)
+            expect(root.attributes('style')).toBe(attrs.style)
+            expect(root.attributes('id')).toBe(attrs.id)
+
+            const tag = wrapper.find('a.navbar-link')
+            expect(tag.classes(attrs.class)).toBe(false)
+            expect(tag.attributes('style')).toBeUndefined()
+            expect(tag.attributes('id')).toBeUndefined()
+        })
+
+        it('should apply class, style, and id to the underlying tag if compatFallthrough is false', () => {
+            const wrapper = shallowMount(BNavbarDropdown, {
+                attrs,
+                props: {
+                    compatFallthrough: false,
+                    tag: 'a'
+                }
+            })
+
+            const root = wrapper.find('div.navbar-item')
+            expect(root.classes(attrs.class)).toBe(false)
+            expect(root.attributes('style')).toBeUndefined()
+            expect(root.attributes('id')).toBeUndefined()
+
+            const tag = wrapper.find('a.navbar-link')
+            expect(tag.classes(attrs.class)).toBe(true)
+            expect(tag.attributes('style')).toBe(attrs.style)
+            expect(tag.attributes('id')).toBe(attrs.id)
+        })
+    })
 })

--- a/packages/buefy-next/src/components/navbar/NavbarDropdown.vue
+++ b/packages/buefy-next/src/components/navbar/NavbarDropdown.vue
@@ -7,6 +7,7 @@
         }"
         @mouseenter="checkHoverable"
         v-click-outside="closeMenu"
+        v-bind="rootAttrs"
     >
         <component
             :is="tag"
@@ -15,7 +16,7 @@
                 'is-arrowless': arrowless,
                 'is-active': newActive && collapsible
             }"
-            v-bind="$attrs"
+            v-bind="fallthroughAttrs"
             aria-haspopup="true"
             @click.prevent="toggleMenu"
             @keyup.enter="toggleMenu"
@@ -41,13 +42,14 @@
 
 <script>
 import clickOutside from '../../directives/clickOutside'
+import CompatFallthroughMixin from '../../utils/CompatFallthroughMixin'
 
 export default {
     name: 'BNavbarDropdown',
     directives: {
         clickOutside
     },
-    inheritAttrs: false,
+    mixins: [CompatFallthroughMixin],
     props: {
         label: String,
         hoverable: Boolean,

--- a/packages/docs/src/pages/components/navbar/api/navbar.js
+++ b/packages/docs/src/pages/components/navbar/api/navbar.js
@@ -176,6 +176,13 @@ export default [
             type: 'Boolean',
             values: '',
             default: 'false'
+        },
+        {
+            name: '<code>compat-fallthrough</code>',
+            description: 'Whether <code>class</code>, <code>style</code>, and <code>id</code> attributes are applied to the root &lt;div&gt; element or the underlying tag. If <code>true</code>, they are applied to the root &lt;div&gt; element, which is compatible with Buefy for Vue 2.',
+            type: 'Boolean',
+            values: '-',
+            default: '<code>true</code>. Can be changed via the <code>defaultCompatFallthrough</code> config option.'
         }
     ],
     slots: [


### PR DESCRIPTION
Related issue:
- #16

## Proposed Changes

- Introduce a new prop `compat-fallthrough` to `NavbarDropdown`, which determines if the `class`, `style`, and `id` attributes are applied to the root `<div>` element or the underlying tag. If `true`, they are applied to the root `<div>` element, which is compatible with Buefy for Vue 2.
- Add test cases for the `compat-fallthrough` prop of `NavbarDropdown`
- Explain the `compat-fallthrough` prop in the `NavbarDropdown` documentation page
- Introduce the `compat-fallthrough` prop of `NavbarDropdown` as a new feature in `CHANGELOG`
