### PR TITLE
Fix [Numberinput]: Vue Compat: deprecation INSTANCE_ATTRS_CLASS_STYLE (#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 
   * `Numberinput`:
 
-    TBD
+    If `compat-fallthrough` is `true`, the attributes fall through to the root `<div>` element, otherwise to the underlying `<b-input>` component.
 
   * `Select`:
 

--- a/packages/buefy-next/src/components/numberinput/Numberinput.spec.js
+++ b/packages/buefy-next/src/components/numberinput/Numberinput.spec.js
@@ -399,4 +399,45 @@ describe('BNumberinput', () => {
             expect(wrapper.vm.computedValue).toBe(5)
         })
     })
+
+    describe('with fallthrough attributes', () => {
+        const attrs = {
+            class: 'fallthrough-class',
+            style: 'font-size: 2rem;',
+            id: 'fallthrough-id'
+        }
+
+        it('should apply class, style, and id to the root <div> element if compatFallthrough is true (default)', () => {
+            const wrapper = shallowMount(BNumberinput, { attrs })
+
+            const root = wrapper.find('div.b-numberinput')
+            expect(root.classes(attrs.class)).toBe(true)
+            expect(root.attributes('style')).toBe(attrs.style)
+            expect(root.attributes('id')).toBe(attrs.id)
+
+            const input = wrapper.findComponent({ ref: 'input' })
+            expect(input.classes(attrs.class)).toBe(false)
+            expect(input.attributes('style')).toBeUndefined()
+            expect(input.attributes('id')).toBeUndefined()
+        })
+
+        it('should apply class, style and id to the underlying <b-input> if compatFallthrough is false', () => {
+            const wrapper = shallowMount(BNumberinput, {
+                attrs,
+                props: {
+                    compatFallthrough: false
+                }
+            })
+
+            const root = wrapper.find('div.b-numberinput')
+            expect(root.classes(attrs.class)).toBe(false)
+            expect(root.attributes('style')).toBeUndefined()
+            expect(root.attributes('id')).toBeUndefined()
+
+            const input = wrapper.findComponent({ ref: 'input' })
+            expect(input.classes(attrs.class)).toBe(true)
+            expect(input.attributes('style')).toBe(attrs.style)
+            expect(input.attributes('id')).toBe(attrs.id)
+        })
+    })
 })

--- a/packages/buefy-next/src/components/numberinput/Numberinput.vue
+++ b/packages/buefy-next/src/components/numberinput/Numberinput.vue
@@ -1,5 +1,9 @@
 <template>
-    <div class="b-numberinput field" :class="fieldClasses">
+    <div
+        class="b-numberinput field"
+        :class="fieldClasses"
+        v-bind="rootAttrs"
+    >
         <p
             v-for="control in controlsLeft"
             :key="control"
@@ -37,7 +41,7 @@
             type="number"
             ref="input"
             v-model="computedValue"
-            v-bind="$attrs"
+            v-bind="fallthroughAttrs"
             :step="minStepNumber"
             :max="max"
             :min="min"
@@ -95,6 +99,7 @@
 <script>
 import Icon from '../icon/Icon.vue'
 import Input from '../input/Input.vue'
+import CompatFallthroughMixin from '../../utils/CompatFallthroughMixin'
 import FormElementMixin from '../../utils/FormElementMixin'
 
 export default {
@@ -103,8 +108,7 @@ export default {
         [Icon.name]: Icon,
         [Input.name]: Input
     },
-    mixins: [FormElementMixin],
-    inheritAttrs: false,
+    mixins: [CompatFallthroughMixin, FormElementMixin],
     inject: {
         field: {
             from: 'BField',

--- a/packages/docs/src/pages/components/numberinput/api/numberinput.js
+++ b/packages/docs/src/pages/components/numberinput/api/numberinput.js
@@ -138,6 +138,13 @@ export default [
                 default: '<code>true</code>'
             },
             {
+                name: '<code>compat-fallthrough</code>',
+                description: 'Whether the <code>class</code>, <code>style</code>, and <code>id</code> attributes are applied to the root &lt;div&gt; element or the underlying &lt;b-input&gt; component. If <code>true</code>, they are applied to the root &lt;div&gt; element, which is compatible with Buefy for Vue 2.',
+                type: 'Boolean',
+                values: '-',
+                default: '<code>true</code>. Can be changed via the <code>defaultCompatFallthrough</code> config option.'
+            },
+            {
                 name: 'Any native attribute',
                 description: '—',
                 type: '—',


### PR DESCRIPTION
Related issue:
- #16

## Proposed Changes

- Introduce a new prop `compat-fallthrough` to `Numberinput`, which determines if the `class`, `style`, and `id` attributes are applied to the root `<div>` element or the underlying `<b-input>` component. If `true`, they are applied to the root `<div>` element, which is compatible with Buefy for Vue 2.
- Add test cases for the `compat-fallthrough` prop of `Numberinput`
- Explain the `compat-fallthrough` prop in the `Numberinput` documentation page
- Introduce the `compat-fallthrough` prop of `Numberinput` as a new feature in `CHANGELOG`
