### PR TITLE
Fix [Taginput]: Vue Compat: deprecation INSTANCE_ATTRS_CLASS_STYLE (#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@
 
   * `Taginput`:
 
-    TBD
+    If `compat-fallthrough` is `true`, the attributes fall through to the root `<div>` element, otherwise to the underlying `<b-autocomplete>` component.
 
   * `Timepicker`:
 

--- a/packages/buefy-next/src/components/taginput/Taginput.spec.js
+++ b/packages/buefy-next/src/components/taginput/Taginput.spec.js
@@ -87,4 +87,45 @@ describe('BTaginput', () => {
         expect(firedHeader).toBeTruthy()
         expect(firedFooter).toBeTruthy()
     })
+
+    describe('with fallthrough attributes', () => {
+        const attrs = {
+            class: 'fallthrough-class',
+            style: 'font-size: 2rem;',
+            id: 'fallthrough-id'
+        }
+
+        it('should apply class, style, and id to the root <div> element if compatFallthrough is true (default)', () => {
+            const wrapper = shallowMount(BTaginput, { attrs })
+
+            const root = wrapper.find('div.taginput')
+            expect(root.classes(attrs.class)).toBe(true)
+            expect(root.attributes('style')).toBe(attrs.style)
+            expect(root.attributes('id')).toBe(attrs.id)
+
+            const autocomplete = wrapper.findComponent({ ref: 'autocomplete' })
+            expect(autocomplete.classes(attrs.class)).toBe(false)
+            expect(autocomplete.attributes('style')).toBeUndefined()
+            expect(autocomplete.attributes('id')).toBeUndefined()
+        })
+
+        it('should apply class, style, and id to the underlying <b-autocomplete> if compatFallthrough is false', () => {
+            const wrapper = shallowMount(BTaginput, {
+                attrs,
+                props: {
+                    compatFallthrough: false
+                }
+            })
+
+            const root = wrapper.find('div.taginput')
+            expect(root.classes(attrs.class)).toBe(false)
+            expect(root.attributes('style')).toBeUndefined()
+            expect(root.attributes('id')).toBeUndefined()
+
+            const autocomplete = wrapper.findComponent({ ref: 'autocomplete' })
+            expect(autocomplete.classes(attrs.class)).toBe(true)
+            expect(autocomplete.attributes('style')).toBe(attrs.style)
+            expect(autocomplete.attributes('id')).toBe(attrs.id)
+        })
+    })
 })

--- a/packages/buefy-next/src/components/taginput/Taginput.vue
+++ b/packages/buefy-next/src/components/taginput/Taginput.vue
@@ -1,5 +1,9 @@
 <template>
-    <div class="taginput control" :class="rootClasses">
+    <div
+        class="taginput control"
+        :class="rootClasses"
+        v-bind="rootAttrs"
+    >
         <div
             class="taginput-container"
             :class="[statusType, size, containerClasses]"
@@ -33,7 +37,7 @@
                 ref="autocomplete"
                 v-if="hasInput"
                 v-model="newTag"
-                v-bind="$attrs"
+                v-bind="fallthroughAttrs"
                 :data="data"
                 :field="field"
                 :icon="icon"
@@ -108,6 +112,7 @@ import { getValueByPath } from '../../utils/helpers'
 import Tag from '../tag/Tag.vue'
 import Autocomplete from '../autocomplete/Autocomplete.vue'
 import config from '../../utils/config'
+import CompatFallthroughMixin from '../../utils/CompatFallthroughMixin'
 import FormElementMixin from '../../utils/FormElementMixin'
 
 export default {
@@ -116,8 +121,7 @@ export default {
         [Autocomplete.name]: Autocomplete,
         [Tag.name]: Tag
     },
-    mixins: [FormElementMixin],
-    inheritAttrs: false,
+    mixins: [CompatFallthroughMixin, FormElementMixin],
     props: {
         modelValue: {
             type: Array,

--- a/packages/docs/src/pages/components/taginput/api/taginput.js
+++ b/packages/docs/src/pages/components/taginput/api/taginput.js
@@ -197,6 +197,13 @@ export default [
                 default: '<code>false</code>'
             },
             {
+                name: '<code>compat-fallthrough</code>',
+                description: 'Whether the <code>class</code>, <code>style</code>, and <code>id</code> attributes are applied to the root &lt;div&gt; element or the underlying &lt;b-autocomplete&gt; component. If <code>true</code>, they are applied to the root &lt;div&gt; element, which is compatible with Buefy for Vue 2.',
+                type: 'Boolean',
+                values: '-',
+                default: '<code>true</code>. Can be changed via the <code>defaultCompatFallthrough</code> config option.'
+            },
+            {
                 name: 'Any other native attribute',
                 description: '—',
                 type: '—',


### PR DESCRIPTION
Related issue:
- #16

## Proposed Changes

- Introduce a new prop `compat-fallthrough` to `Taginput`, which determines if the `class`, `style`, and `id` attributes are applied to the root `<div>` element or the underlying `<b-autocomplete>` component. If `true`, they are applied to the root `<div>` element, which is compatible with Buefy for Vue 2.
- Add test cases for the `compat-fallthrough` prop of `Taginput`
- Explain the `compat-fallthrough` prop in the `Taginput` documentation page
- Introduce the `compat-fallthrough` prop of `Taginput` as a new feature in `CHANGELOG`