### PR TITLE
Fix [Upload]: Vue Compat: deprecation INSTANCE_ATTRS_CLASS_STYLE (#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@
 
   * `Upload`:
 
-    TBD
+    If `compat-fallthrough` is `true`, the attributes fall through to the root `<label>` element, otherwise to the underlying `<input>` element.
 
 * `CarouselItem`, `StepItem`, and `TabItem` introduce a new prop `order`, which determines the order of each child item.
   By default, the order of each child item is determined by the sequence in which each child item is mounted.

--- a/packages/buefy-next/src/components/upload/Upload.spec.js
+++ b/packages/buefy-next/src/components/upload/Upload.spec.js
@@ -16,4 +16,45 @@ describe('BUpload', () => {
     it('render correctly', () => {
         expect(wrapper.html()).toMatchSnapshot()
     })
+
+    describe('with fallthrough attributes', () => {
+        const attrs = {
+            class: 'fallthrough-class',
+            style: 'font-size: 2rem;',
+            id: 'fallthrough-id'
+        }
+
+        it('should apply class, style, and id to the root <label> element if compatFallthrough is true (default)', () => {
+            const wrapper = shallowMount(BUpload, { attrs })
+
+            const root = wrapper.find('label.upload')
+            expect(root.classes(attrs.class)).toBe(true)
+            expect(root.attributes('style')).toBe(attrs.style)
+            expect(root.attributes('id')).toBe(attrs.id)
+
+            const input = wrapper.find({ ref: 'input' })
+            expect(input.classes(attrs.class)).toBe(false)
+            expect(input.attributes('style')).toBeUndefined()
+            expect(input.attributes('id')).toBeUndefined()
+        })
+
+        it('should apply class, style, and id to the underlying <input> element if compatFallthrough is false', () => {
+            const wrapper = shallowMount(BUpload, {
+                attrs,
+                props: {
+                    compatFallthrough: false
+                }
+            })
+
+            const root = wrapper.find('label.upload')
+            expect(root.classes(attrs.class)).toBe(false)
+            expect(root.attributes('style')).toBeUndefined()
+            expect(root.attributes('id')).toBeUndefined()
+
+            const input = wrapper.find({ ref: 'input' })
+            expect(input.classes(attrs.class)).toBe(true)
+            expect(input.attributes('style')).toBe(attrs.style)
+            expect(input.attributes('id')).toBe(attrs.id)
+        })
+    })
 })

--- a/packages/buefy-next/src/components/upload/Upload.vue
+++ b/packages/buefy-next/src/components/upload/Upload.vue
@@ -1,7 +1,7 @@
 <template>
     <label
         class="upload control"
-        v-bind="classAndStyle"
+        v-bind="rootAttrs"
         :class="[{'is-expanded' : expanded, 'is-rounded' : rounded}]"
     >
         <template v-if="!dragDrop">
@@ -28,7 +28,7 @@
         <input
             ref="input"
             type="file"
-            v-bind="$attrs"
+            v-bind="fallthroughAttrs"
             :multiple="multiple"
             :accept="accept"
             :disabled="disabledOrUndefined"
@@ -38,13 +38,13 @@
 </template>
 
 <script>
+import CompatFallthroughMixin from '../../utils/CompatFallthroughMixin'
 import FormElementMixin from '../../utils/FormElementMixin'
 import { File } from '../../utils/ssr'
 
 export default {
     name: 'BUpload',
-    mixins: [FormElementMixin],
-    inheritAttrs: false,
+    mixins: [CompatFallthroughMixin, FormElementMixin],
     props: {
         modelValue: {
             type: [Object, Function, File, Array]
@@ -79,12 +79,6 @@ export default {
         }
     },
     computed: {
-        classAndStyle() {
-            return {
-                class: this.$attrs.class,
-                style: this.$attrs.style
-            }
-        },
         disabledOrUndefined() {
             // On Vue 3, setting a boolean attribute `false` does not remove it,
             // `true` or `undefined` has to be given to remove it.

--- a/packages/docs/src/pages/components/upload/api/upload.js
+++ b/packages/docs/src/pages/components/upload/api/upload.js
@@ -88,6 +88,13 @@ export default [
                 values: '—',
                 default: '<code>false</code>'
             },
+            {
+                name: '<code>compat-fallthrough</code>',
+                description: 'Whether the <code>class</code>, <code>style</code>, and <code>id</code> attributes are applied to the root &lt;label&gt; element or the underlying &lt;input&gt; element. If <code>true</code>, they are applied to the root &lt;label&gt; element, which is compatible with Buefy for Vue 2.',
+                type: 'Boolean',
+                values: '-',
+                default: '<code>true</code>. Can be changed via the <code>defaultCompatFallthrough</code> config option.'
+            }
         ],
         events: [
             {


### PR DESCRIPTION
Related issue:
- #16

## Proposed Changes

- Introduce a new prop `compat-fallthrough` to `Upload`, which determines if the `class`, `style`, and `id` attributes are  applied to the root `<label>` element or the underlying `<input>` element. If `true`, they are applied to the root `<label>` element, which is compatible with Buefy for Vue 2.
  - Replace the `classAndStyle` computed value with `rootAttrs`, which did not address the `id` attribute
- Add test cases for the `compat-fallthrough` prop of `Upload`
- Explain the `compat-fallthrough` prop in the `Upload` documentation page
- Introduce the `compat-fallthrough` prop of `Upload` as a new feature in `CHANGELOG`
