### PR TITLE
Cherry pick 0.9.28 to 0.9.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@
 ### Fixes
 
 * Fix [#4017](https://github.com/buefy/buefy/issues/4017) `Tooltip` - AbortController is not defined in SSR mode (Nuxt)
+* Fix [#4018](https://github.com/buefy/buefy/issues/4018) Browser tab froze when `Field` with both `grouped` and `horizontal` props `true` got a validation error. However, there is another issue that validation errors cannot be reset once they are set if `grouped` and `horizontal` are combined.
 
 ## 0.9.28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,7 +125,7 @@
 * A lot of ESLint errors, and warnings are fixed, as the ESLint rule version has been upgraded.
 * The type of the `cancelText` prop of `Snackbar` is fixed. It used to be `String | null`, and ended up with a type error. It is now `String`.
 
-## 0.9.29 Unreleased
+## 0.9.29
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,12 @@
 * A lot of ESLint errors, and warnings are fixed, as the ESLint rule version has been upgraded.
 * The type of the `cancelText` prop of `Snackbar` is fixed. It used to be `String | null`, and ended up with a type error. It is now `String`.
 
+## 0.9.29 Unreleased
+
+### Fixes
+
+* Fix [#4017](https://github.com/buefy/buefy/issues/4017) `Tooltip` - AbortController is not defined in SSR mode (Nuxt)
+
 ## 0.9.28
 
 ### New features

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,9 +30,9 @@
       }
     },
     "node_modules/@adobe/css-tools": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.1.tgz",
-      "integrity": "sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.3.tgz",
+      "integrity": "sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==",
       "dev": true
     },
     "node_modules/@ampproject/remapping": {
@@ -8572,9 +8572,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "dev": true,
       "funding": [
         {
@@ -9710,9 +9710,9 @@
       }
     },
     "node_modules/ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
       "dev": true
     },
     "node_modules/is-array-buffer": {
@@ -17946,9 +17946,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.0.tgz",
-      "integrity": "sha512-ulr8rNLA6rkyFAlVWw2q5YJ91v098AFQ2R0PRFwPzREXOUJQPtFUG0t+/ZikhaOCDqFoDhN6/v8Sq0o4araFAw==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.3.tgz",
+      "integrity": "sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",

--- a/packages/buefy-next/src/components/field/Field.spec.js
+++ b/packages/buefy-next/src/components/field/Field.spec.js
@@ -262,4 +262,55 @@ describe('BField', () => {
             expect(helpWrapper.text()).toEqual(message)
         })
     })
+
+    describe('with grouped and horizontal true', () => {
+        let wrapper
+
+        beforeEach(() => {
+            wrapper = mount(BField, {
+                props: {
+                    grouped: true,
+                    horizontal: true
+                },
+                slots: {
+                    default: [BInput, BInput]
+                },
+                global: {
+                    components
+                }
+            })
+        })
+
+        it('should wrap each child in a field under a field-body', () => {
+            const body = wrapper.findComponent(BFieldBody)
+            expect(body.exists()).toBe(true)
+            const childFields = body.findAllComponents(BField)
+            expect(childFields.length).toBe(2)
+            expect(childFields[0].findComponent(BInput).exists()).toBe(true)
+            expect(childFields[1].findComponent(BInput).exists()).toBe(true)
+        })
+
+        describe('when validation fails', () => {
+            let childFields
+
+            beforeEach(async () => {
+                await wrapper.setData({
+                    newType: 'is-danger',
+                    newMessage: 'error message'
+                })
+                const body = wrapper.findComponent(BFieldBody)
+                childFields = body.findAllComponents(BField)
+            })
+
+            it('should set message only to the first child field', () => {
+                expect(childFields[0].props('message')).toEqual(['error message'])
+                expect(childFields[1].props('message')).toBeUndefined()
+            })
+
+            it('should set type to all the child fields', () => {
+                expect(childFields[0].props('type')).toBe('is-danger')
+                expect(childFields[1].props('type')).toBe('is-danger')
+            })
+        })
+    })
 })

--- a/packages/buefy-next/src/components/field/Field.vue
+++ b/packages/buefy-next/src/components/field/Field.vue
@@ -212,7 +212,14 @@ export default {
         * Set internal message when prop change.
         */
         message(value) {
-            this.newMessage = value
+            // we deep comparison here becase an innner Field of another Field
+            // receives the message as a brand new array every time, so simple
+            // identity check won't work and will end up with infinite
+            // recursions
+            // https://github.com/buefy/buefy/issues/4018#issuecomment-1985026234
+            if (JSON.stringify(value) !== JSON.stringify(this.newMessage)) {
+                this.newMessage = value
+            }
         },
 
         /**

--- a/packages/buefy-next/src/components/tooltip/Tooltip.vue
+++ b/packages/buefy-next/src/components/tooltip/Tooltip.vue
@@ -290,8 +290,8 @@ export default {
         }
     },
     mounted() {
-        this.controller = new window.AbortController()
         if (this.appendToBody && typeof window !== 'undefined') {
+            this.controller = new window.AbortController()
             this.$data._bodyEl = createAbsoluteElement(this.$refs.content)
             this.updateAppendToBody()
             // updates the tooltip position if the tooltip is inside
@@ -336,7 +336,9 @@ export default {
         if (this.appendToBody) {
             removeElement(this.$data._bodyEl)
         }
-        this.controller.abort()
+        if (this.controller != null) {
+            this.controller.abort()
+        }
         clearTimeout(this.timer)
         clearTimeout(this.timeOutID)
     }

--- a/packages/docs/src/pages/Home.vue
+++ b/packages/docs/src/pages/Home.vue
@@ -24,7 +24,7 @@
                                 <b-icon icon="github-circle" size="is-small" />
                             </a>)
                         </p>
-                        <pre class="npm"><code><span class="is-unselectable">$ </span>npm install @ntohq/buefy-next</code></pre>
+                        <pre class="npm"><code><span class="is-unselectable">$ </span>npm install buefy@npm:@ntohq/buefy-next</code></pre>
                     </div>
 
                     <div class="github-button home-hero">

--- a/packages/docs/src/pages/components/field/api/field.js
+++ b/packages/docs/src/pages/components/field/api/field.js
@@ -41,7 +41,7 @@ export default [
             },
             {
                 name: '<code>grouped</code>',
-                description: 'Direct child components/elements of Field will be grouped horizontally (see which ones at the top of the page)',
+                description: 'Direct child components/elements of Field will be grouped horizontally (see which ones at the top of the page). Do not mix with <code>horizontal</code> because there is an issue that the validation error cannot be reset once it is set if combined with <code>horizontal</code>.',
                 type: 'Boolean',
                 values: '—',
                 default: '<code>false</code>'
@@ -69,7 +69,7 @@ export default [
             },
             {
                 name: '<code>horizontal</code>',
-                description: 'Group label and control on the same line for horizontal forms',
+                description: 'Group label and control on the same line for horizontal forms. Do not mix with <code>grouped</code> because there is an issue that the validation error cannot be reset once it is set if combined with <code>grouped</code>.',
                 type: 'Boolean',
                 values: '—',
                 default: '<code>false</code>'


### PR DESCRIPTION
Fixes #
- fixes #220 

## Proposed Changes

- Cherry-pick commits made in Buefy for Vue 2 between v0.9.28 and v0.9.29. For more details, please refer to the issue #220
  - One remarkable issue was that I was not able to provide a CodePen template for `buefy-next`