### PR TITLE
Remove Unnecessary Property `style` Causing Console Warnings

### DIFF
--- a/packages/docs/src/components/CodepenEdit.vue
+++ b/packages/docs/src/components/CodepenEdit.vue
@@ -50,6 +50,7 @@ export default {
             return JSON.stringify({
                 title: `${this.$route.meta.title} ${this.title ? this.title.toLowerCase() : ''} - Buefy example`,
                 tags: ['buefy', 'vue', 'bulma'],
+                editors: 101,
                 layout: 'right',
                 html: this.getHtml(),
                 js: this.getScript(),

--- a/packages/docs/src/components/CodepenEdit.vue
+++ b/packages/docs/src/components/CodepenEdit.vue
@@ -50,7 +50,6 @@ export default {
             return JSON.stringify({
                 title: `${this.$route.meta.title} ${this.title ? this.title.toLowerCase() : ''} - Buefy example`,
                 tags: ['buefy', 'vue', 'bulma'],
-                editors: this.style ? 111 : 101,
                 layout: 'right',
                 html: this.getHtml(),
                 js: this.getScript(),


### PR DESCRIPTION
Fixes #178

## Proposed Changes
- Remove [line 53 from `CodepenEdit.vue`](https://github.com/ntohq/buefy-next/blob/e016e37f859eec9dc4e8e1e594762bc4e0a66e11/packages/docs/src/components/CodepenEdit.vue#L53C1-L53C49) component in the docs  to prevent unnecessary warnings.

#### How to Test this PR?
1. Start up the Buefy docs development server by running:
    `cd /packages/docs/`
    `npm run dev`
2. using your browser navigate to `http://localhost:5173/` then navigate to any component.
3. Open your browsers dev tools.
4. Confirm that these types of warnings are no longer present
![image](https://github.com/ntohq/buefy-next/assets/11604664/e9c6964a-ea35-4db6-bf44-d50239a0a4c8)



