### PR TITLE
Remove Use from All Components

### DIFF
--- a/packages/buefy-next/src/components/autocomplete/index.js
+++ b/packages/buefy-next/src/components/autocomplete/index.js
@@ -8,8 +8,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/autocomplete/index.js
+++ b/packages/buefy-next/src/components/autocomplete/index.js
@@ -1,6 +1,6 @@
 import Autocomplete from './Autocomplete.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/breadcrumb/index.js
+++ b/packages/buefy-next/src/components/breadcrumb/index.js
@@ -10,8 +10,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/breadcrumb/index.js
+++ b/packages/buefy-next/src/components/breadcrumb/index.js
@@ -1,7 +1,7 @@
 import Breadcrumb from './Breadcrumb.vue'
 import BreadcrumbItem from './BreadcrumbItem.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/button/index.js
+++ b/packages/buefy-next/src/components/button/index.js
@@ -8,8 +8,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/button/index.js
+++ b/packages/buefy-next/src/components/button/index.js
@@ -1,6 +1,6 @@
 import Button from './Button.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/carousel/index.js
+++ b/packages/buefy-next/src/components/carousel/index.js
@@ -12,8 +12,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/carousel/index.js
+++ b/packages/buefy-next/src/components/carousel/index.js
@@ -2,7 +2,7 @@ import Carousel from './Carousel.vue'
 import CarouselItem from './CarouselItem.vue'
 import CarouselList from './CarouselList.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/checkbox/index.js
+++ b/packages/buefy-next/src/components/checkbox/index.js
@@ -10,8 +10,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/checkbox/index.js
+++ b/packages/buefy-next/src/components/checkbox/index.js
@@ -1,7 +1,7 @@
 import Checkbox from './Checkbox.vue'
 import CheckboxButton from './CheckboxButton.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/clockpicker/index.js
+++ b/packages/buefy-next/src/components/clockpicker/index.js
@@ -8,8 +8,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/clockpicker/index.js
+++ b/packages/buefy-next/src/components/clockpicker/index.js
@@ -1,6 +1,6 @@
 import Clockpicker from './Clockpicker.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/collapse/index.js
+++ b/packages/buefy-next/src/components/collapse/index.js
@@ -8,8 +8,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/collapse/index.js
+++ b/packages/buefy-next/src/components/collapse/index.js
@@ -1,6 +1,6 @@
 import Collapse from './Collapse.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/colorpicker/index.js
+++ b/packages/buefy-next/src/components/colorpicker/index.js
@@ -8,8 +8,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/colorpicker/index.js
+++ b/packages/buefy-next/src/components/colorpicker/index.js
@@ -1,6 +1,6 @@
 import Colorpicker from './Colorpicker.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/datepicker/index.js
+++ b/packages/buefy-next/src/components/datepicker/index.js
@@ -8,8 +8,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/datepicker/index.js
+++ b/packages/buefy-next/src/components/datepicker/index.js
@@ -1,6 +1,6 @@
 import Datepicker from './Datepicker.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/datetimepicker/index.js
+++ b/packages/buefy-next/src/components/datetimepicker/index.js
@@ -8,8 +8,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/datetimepicker/index.js
+++ b/packages/buefy-next/src/components/datetimepicker/index.js
@@ -1,6 +1,6 @@
 import Datetimepicker from './Datetimepicker.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/dialog/index.js
+++ b/packages/buefy-next/src/components/dialog/index.js
@@ -133,8 +133,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/dialog/index.js
+++ b/packages/buefy-next/src/components/dialog/index.js
@@ -4,7 +4,7 @@ import Dialog from './Dialog.vue'
 
 import config from '../../utils/config'
 import { merge, copyAppContext, getComponentFromVNode } from '../../utils/helpers'
-import { use, registerComponent, registerComponentProgrammatic } from '../../utils/plugins'
+import { registerComponent, registerComponentProgrammatic } from '../../utils/plugins'
 
 function open(propsData, app) {
     let slot

--- a/packages/buefy-next/src/components/dropdown/index.js
+++ b/packages/buefy-next/src/components/dropdown/index.js
@@ -10,8 +10,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/dropdown/index.js
+++ b/packages/buefy-next/src/components/dropdown/index.js
@@ -1,7 +1,7 @@
 import Dropdown from './Dropdown.vue'
 import DropdownItem from './DropdownItem.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/field/index.js
+++ b/packages/buefy-next/src/components/field/index.js
@@ -8,8 +8,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/field/index.js
+++ b/packages/buefy-next/src/components/field/index.js
@@ -1,6 +1,6 @@
 import Field from './Field.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/icon/index.js
+++ b/packages/buefy-next/src/components/icon/index.js
@@ -8,8 +8,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/icon/index.js
+++ b/packages/buefy-next/src/components/icon/index.js
@@ -1,6 +1,6 @@
 import Icon from './Icon.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/image/index.js
+++ b/packages/buefy-next/src/components/image/index.js
@@ -1,6 +1,6 @@
 import Image from './Image.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/image/index.js
+++ b/packages/buefy-next/src/components/image/index.js
@@ -8,8 +8,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/input/index.js
+++ b/packages/buefy-next/src/components/input/index.js
@@ -1,6 +1,6 @@
 import Input from './Input.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/input/index.js
+++ b/packages/buefy-next/src/components/input/index.js
@@ -8,8 +8,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/loading/index.js
+++ b/packages/buefy-next/src/components/loading/index.js
@@ -65,8 +65,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/loading/index.js
+++ b/packages/buefy-next/src/components/loading/index.js
@@ -3,7 +3,7 @@ import { createApp, h as createElement } from 'vue'
 import Loading from './Loading.vue'
 
 import { merge, copyAppContext, getComponentFromVNode } from '../../utils/helpers'
-import { use, registerComponent, registerComponentProgrammatic } from '../../utils/plugins'
+import { registerComponent, registerComponentProgrammatic } from '../../utils/plugins'
 
 class LoadingProgrammatic {
     constructor(app) {

--- a/packages/buefy-next/src/components/menu/index.js
+++ b/packages/buefy-next/src/components/menu/index.js
@@ -14,8 +14,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/menu/index.js
+++ b/packages/buefy-next/src/components/menu/index.js
@@ -2,7 +2,7 @@ import Menu from './Menu.vue'
 import MenuList from './MenuList.vue'
 import MenuItem from './MenuItem.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/message/index.js
+++ b/packages/buefy-next/src/components/message/index.js
@@ -1,6 +1,6 @@
 import Message from './Message.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/message/index.js
+++ b/packages/buefy-next/src/components/message/index.js
@@ -8,8 +8,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/modal/index.js
+++ b/packages/buefy-next/src/components/modal/index.js
@@ -81,8 +81,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/modal/index.js
+++ b/packages/buefy-next/src/components/modal/index.js
@@ -3,7 +3,7 @@ import { createApp, h as createElement } from 'vue'
 import Modal from './Modal.vue'
 
 import { merge, copyAppContext, getComponentFromVNode } from '../../utils/helpers'
-import { use, registerComponent, registerComponentProgrammatic } from '../../utils/plugins'
+import { registerComponent, registerComponentProgrammatic } from '../../utils/plugins'
 
 class ModalProgrammatic {
     constructor(app) {

--- a/packages/buefy-next/src/components/navbar/index.js
+++ b/packages/buefy-next/src/components/navbar/index.js
@@ -12,8 +12,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/navbar/index.js
+++ b/packages/buefy-next/src/components/navbar/index.js
@@ -2,7 +2,7 @@ import Navbar from './Navbar.vue'
 import NavbarItem from './NavbarItem.vue'
 import NavbarDropdown from './NavbarDropdown.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/notification/index.js
+++ b/packages/buefy-next/src/components/notification/index.js
@@ -96,8 +96,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/notification/index.js
+++ b/packages/buefy-next/src/components/notification/index.js
@@ -5,7 +5,7 @@ import NotificationNotice from './NotificationNotice.vue'
 
 import config from '../../utils/config'
 import { merge, copyAppContext, getComponentFromVNode } from '../../utils/helpers'
-import { use, registerComponent, registerComponentProgrammatic } from '../../utils/plugins'
+import { registerComponent, registerComponentProgrammatic } from '../../utils/plugins'
 
 class NotificationProgrammatic {
     constructor(app) {

--- a/packages/buefy-next/src/components/numberinput/index.js
+++ b/packages/buefy-next/src/components/numberinput/index.js
@@ -8,8 +8,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/numberinput/index.js
+++ b/packages/buefy-next/src/components/numberinput/index.js
@@ -1,6 +1,6 @@
 import Numberinput from './Numberinput.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/pagination/index.js
+++ b/packages/buefy-next/src/components/pagination/index.js
@@ -10,8 +10,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/pagination/index.js
+++ b/packages/buefy-next/src/components/pagination/index.js
@@ -1,7 +1,7 @@
 import Pagination from './Pagination.vue'
 import PaginationButton from './PaginationButton.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/progress/index.js
+++ b/packages/buefy-next/src/components/progress/index.js
@@ -10,8 +10,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/progress/index.js
+++ b/packages/buefy-next/src/components/progress/index.js
@@ -1,7 +1,7 @@
 import Progress from './Progress.vue'
 import ProgressBar from './ProgressBar.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/radio/index.js
+++ b/packages/buefy-next/src/components/radio/index.js
@@ -10,8 +10,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/radio/index.js
+++ b/packages/buefy-next/src/components/radio/index.js
@@ -1,7 +1,7 @@
 import Radio from './Radio.vue'
 import RadioButton from './RadioButton.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/rate/index.js
+++ b/packages/buefy-next/src/components/rate/index.js
@@ -8,8 +8,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/rate/index.js
+++ b/packages/buefy-next/src/components/rate/index.js
@@ -1,6 +1,6 @@
 import Rate from './Rate.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/select/index.js
+++ b/packages/buefy-next/src/components/select/index.js
@@ -8,8 +8,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/select/index.js
+++ b/packages/buefy-next/src/components/select/index.js
@@ -1,6 +1,6 @@
 import Select from './Select.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/sidebar/index.js
+++ b/packages/buefy-next/src/components/sidebar/index.js
@@ -8,8 +8,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/sidebar/index.js
+++ b/packages/buefy-next/src/components/sidebar/index.js
@@ -1,6 +1,6 @@
 import Sidebar from './Sidebar.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/skeleton/index.js
+++ b/packages/buefy-next/src/components/skeleton/index.js
@@ -10,8 +10,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/skeleton/index.js
+++ b/packages/buefy-next/src/components/skeleton/index.js
@@ -1,6 +1,6 @@
 import Skeleton from './Skeleton.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/slider/index.js
+++ b/packages/buefy-next/src/components/slider/index.js
@@ -10,8 +10,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/slider/index.js
+++ b/packages/buefy-next/src/components/slider/index.js
@@ -1,7 +1,7 @@
 import Slider from './Slider.vue'
 import SliderTick from './SliderTick.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/snackbar/index.js
+++ b/packages/buefy-next/src/components/snackbar/index.js
@@ -4,7 +4,7 @@ import Snackbar from './Snackbar.vue'
 
 import config from '../../utils/config'
 import { merge, copyAppContext, getComponentFromVNode } from '../../utils/helpers'
-import { use, registerComponentProgrammatic } from '../../utils/plugins'
+import { registerComponentProgrammatic } from '../../utils/plugins'
 
 class SnackbarProgrammatic {
     constructor(app) {

--- a/packages/buefy-next/src/components/snackbar/index.js
+++ b/packages/buefy-next/src/components/snackbar/index.js
@@ -86,8 +86,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/steps/index.js
+++ b/packages/buefy-next/src/components/steps/index.js
@@ -10,8 +10,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/steps/index.js
+++ b/packages/buefy-next/src/components/steps/index.js
@@ -1,7 +1,7 @@
 import Steps from './Steps.vue'
 import StepItem from './StepItem.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/switch/index.js
+++ b/packages/buefy-next/src/components/switch/index.js
@@ -8,8 +8,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/switch/index.js
+++ b/packages/buefy-next/src/components/switch/index.js
@@ -1,6 +1,6 @@
 import Switch from './Switch.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/table/index.js
+++ b/packages/buefy-next/src/components/table/index.js
@@ -15,8 +15,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/table/index.js
+++ b/packages/buefy-next/src/components/table/index.js
@@ -1,7 +1,7 @@
 import Table from './Table.vue'
 import TableColumn from './TableColumn.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 import { VueInstance, setVueInstance } from '../../utils/config'
 
 const Plugin = {

--- a/packages/buefy-next/src/components/tabs/index.js
+++ b/packages/buefy-next/src/components/tabs/index.js
@@ -10,8 +10,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/tabs/index.js
+++ b/packages/buefy-next/src/components/tabs/index.js
@@ -1,7 +1,7 @@
 import Tabs from './Tabs.vue'
 import TabItem from './TabItem.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/tag/index.js
+++ b/packages/buefy-next/src/components/tag/index.js
@@ -10,8 +10,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/tag/index.js
+++ b/packages/buefy-next/src/components/tag/index.js
@@ -1,7 +1,7 @@
 import Tag from './Tag.vue'
 import Taglist from './Taglist.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/taginput/index.js
+++ b/packages/buefy-next/src/components/taginput/index.js
@@ -8,8 +8,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/taginput/index.js
+++ b/packages/buefy-next/src/components/taginput/index.js
@@ -1,6 +1,6 @@
 import Taginput from './Taginput.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/timepicker/index.js
+++ b/packages/buefy-next/src/components/timepicker/index.js
@@ -8,8 +8,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/timepicker/index.js
+++ b/packages/buefy-next/src/components/timepicker/index.js
@@ -1,6 +1,6 @@
 import Timepicker from './Timepicker.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/toast/index.js
+++ b/packages/buefy-next/src/components/toast/index.js
@@ -4,7 +4,7 @@ import Toast from './Toast.vue'
 
 import config from '../../utils/config'
 import { merge, copyAppContext, getComponentFromVNode } from '../../utils/helpers'
-import { use, registerComponentProgrammatic } from '../../utils/plugins'
+import { registerComponentProgrammatic } from '../../utils/plugins'
 
 class ToastProgrammatic {
     constructor(app) {

--- a/packages/buefy-next/src/components/toast/index.js
+++ b/packages/buefy-next/src/components/toast/index.js
@@ -88,8 +88,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/tooltip/index.js
+++ b/packages/buefy-next/src/components/tooltip/index.js
@@ -1,6 +1,6 @@
 import Tooltip from './Tooltip.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {

--- a/packages/buefy-next/src/components/tooltip/index.js
+++ b/packages/buefy-next/src/components/tooltip/index.js
@@ -8,8 +8,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/upload/index.js
+++ b/packages/buefy-next/src/components/upload/index.js
@@ -8,8 +8,6 @@ const Plugin = {
     }
 }
 
-use(Plugin)
-
 export default Plugin
 
 export {

--- a/packages/buefy-next/src/components/upload/index.js
+++ b/packages/buefy-next/src/components/upload/index.js
@@ -1,6 +1,6 @@
 import Upload from './Upload.vue'
 
-import { use, registerComponent } from '../../utils/plugins'
+import { registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {


### PR DESCRIPTION
Fixes: #177

### Proposed Changes
- Removes `use(Plugin)` from all of Buefy's components.

### How to Test?
**A. Confirm that `use(Plugin)` was removed from all of Buefy's components**
- This includes all instances within each component(i.e import statements etc...)
**B. Attempt to build buefy-next or confirm that all of the GitHub Actions have run successfully**
1. clone this PR or the `RemoveUse` branch
2. Then run
```bash
cd /packages/buefy-next
npm i && npm run build
```
**C. Run the dev server and confirm that everything is still working properly**
1. clone this PR or the `RemoveUse` branch
2. Then run
```bash
cd /packages/docs
npm i && npm run dev
```
4. In your browser navigate to `http://localhost:5173/`
5. Navigate to several (or all) components pages
6. Conform that everything looks normal and check the dev tools console to confirm that no errors have occurred.