### PR TITLE
Set Modal's Event Prop's Default Value

### DIFF
--- a/packages/buefy-next/src/components/modal/Modal.vue
+++ b/packages/buefy-next/src/components/modal/Modal.vue
@@ -68,7 +68,10 @@ export default {
         content: [String, Array],
         programmatic: Boolean,
         props: Object,
-        events: Object,
+        events: {
+            type: Object,
+            default: {}
+        },
         width: {
             type: [String, Number],
             default: 960

--- a/packages/buefy-next/src/components/modal/Modal.vue
+++ b/packages/buefy-next/src/components/modal/Modal.vue
@@ -70,7 +70,9 @@ export default {
         props: Object,
         events: {
             type: Object,
-            default: {}
+            default() {
+                return {}
+            }
         },
         width: {
             type: [String, Number],


### PR DESCRIPTION
Fixes #182

## Proposed Changes
- As a work around to the warning in #182 by default set the Modal's event prop to an empty object. 

