### PR TITLE
fix: update import path for ClockpickerFace and NotificationNotice

### DIFF
--- a/packages/buefy-next/src/components/clockpicker/Clockpicker.vue
+++ b/packages/buefy-next/src/components/clockpicker/Clockpicker.vue
@@ -177,7 +177,7 @@ import Input from '../input/Input.vue'
 import Field from '../field/Field.vue'
 import Icon from '../icon/Icon.vue'
 
-import ClockpickerFace from './ClockpickerFace'
+import ClockpickerFace from './ClockpickerFace.vue'
 
 const outerPadding = 12
 

--- a/packages/buefy-next/src/components/notification/NotificationNotice.vue
+++ b/packages/buefy-next/src/components/notification/NotificationNotice.vue
@@ -31,7 +31,7 @@
 import config from '../../utils/config'
 import { removeElement } from '../../utils/helpers'
 import NoticeMixinSubset from './NoticeMixinSubset'
-import Notification from './Notification'
+import Notification from './Notification.vue'
 
 export default {
     name: 'BNotificationNotice',


### PR DESCRIPTION
This PR adds missing `.vue` extensions for imports in the Clockpicker and NotificationNotice components.
