### PR TITLE
 test(lib): rewrite Switch.spec in TS

### DIFF
--- a/packages/buefy-next/src/components/switch/Switch.spec.ts
+++ b/packages/buefy-next/src/components/switch/Switch.spec.ts
@@ -1,7 +1,9 @@
 import { shallowMount } from '@vue/test-utils'
-import BSwitch from '@components/switch/Switch'
+import type { VueWrapper } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import BSwitch from '@components/switch/Switch.vue'
 
-let wrapper
+let wrapper: VueWrapper<InstanceType<typeof BSwitch>>
 
 describe('BSwitch', () => {
     beforeEach(() => {
@@ -43,10 +45,10 @@ describe('BSwitch', () => {
     })
 
     it('method focus() gives focus to the input element', async () => {
-        wrapper.vm.$refs.input.focus = jest.fn()
+        (wrapper.vm.$refs.input as HTMLElement).focus = vi.fn()
         wrapper.vm.focus()
         await wrapper.vm.$nextTick()
-        expect(wrapper.vm.$refs.input.focus).toHaveBeenCalled()
+        expect((wrapper.vm.$refs.input as HTMLElement).focus).toHaveBeenCalled()
     })
 
     it('applies passiveType prop properly', async () => {

--- a/packages/buefy-next/src/components/switch/__snapshots__/Switch.spec.js.snap
+++ b/packages/buefy-next/src/components/switch/__snapshots__/Switch.spec.js.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`BSwitch render correctly 1`] = `<label class="switch is-rounded"><input type="checkbox" true-value="true" false-value="false" value="false"><span class="check"></span><span class="control-label">Control label</span></label>`;

--- a/packages/buefy-next/src/components/switch/__snapshots__/Switch.spec.ts.snap
+++ b/packages/buefy-next/src/components/switch/__snapshots__/Switch.spec.ts.snap
@@ -1,0 +1,3 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`BSwitch > render correctly 1`] = `"<label class=\\"switch is-rounded\\"><input type=\\"checkbox\\" true-value=\\"true\\" false-value=\\"false\\" value=\\"false\\"><span class=\\"check\\"></span><span class=\\"control-label\\">Control label</span></label>"`;


### PR DESCRIPTION
- Rewrites `components/switch/Switch.spec.js` in TypeScript:
  - Replaces the extension: ".js" → ".ts"
  - Imports necessary functions from `vitest`
  - Appends the ".vue" extension to the import path of `BSwitch`
  - Types `wrapper` -

  Replaces `Switch.spec.js.snap` with `Switch.spec.ts.snap`
  which is produced by `vitest`.
