### PR TITLE
Remove Bluebird from the Docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4250,12 +4250,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "dev": true
-    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -11639,7 +11633,6 @@
         "@mdi/font": "^6.9.96",
         "@vitejs/plugin-vue": "^4.2.3",
         "axios": "^1.5.1",
-        "bluebird": "^3.7.2",
         "bulma-css-vars": "0.8.0",
         "cleave.js": "1.0.1",
         "clipboard": "^2.0.11",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -29,7 +29,6 @@
     "@mdi/font": "^6.9.96",
     "@vitejs/plugin-vue": "^4.2.3",
     "axios": "^1.5.1",
-    "bluebird": "^3.7.2",
     "bulma-css-vars": "0.8.0",
     "cleave.js": "1.0.1",
     "clipboard": "^2.0.11",

--- a/packages/docs/src/main.js
+++ b/packages/docs/src/main.js
@@ -9,7 +9,6 @@ import Axios from 'axios'
 // import VueProgressBar from 'vue-progressbar'
 // TODO: use vue-gtag-next?
 // import VueAnalytics from 'vue-analytics'
-import Bluebird from 'bluebird'
 import hljs from 'highlight.js'
 
 import ApiView from './components/ApiView.vue'
@@ -35,7 +34,6 @@ vueApp.config.productionTip = false
 // Webpack inserts `global` but Vite does not
 // https://stackoverflow.com/a/73208485
 window.global ||= window
-global.Promise = Bluebird
 
 vueApp.config.globalProperties.$http = Axios
 vueApp.config.globalProperties.$eventHub = new Emitter()


### PR DESCRIPTION
Fixes #171

## Proposed Changes
- Remove Bluebird 
> Buefy's documentation app uses [bluebird](https://github.com/petkaantonov/bluebird) as the Promise implementation. I do not think Buefy docs needs bluebird specific features. ~ @kikuomax 

#### How to test
1. Run the documentation websites dev server
2. Browse (using your preferred browser) different routes on the website checking the console in the browser and the console for any errors (I couldn't find any).
