### PR TITLE
Add Missing Prop and Import Statement to the Colorpicker

### DIFF
--- a/packages/buefy-next/src/components/colorpicker/Colorpicker.spec.js
+++ b/packages/buefy-next/src/components/colorpicker/Colorpicker.spec.js
@@ -7,6 +7,7 @@ describe('BColorpicker', () => {
             global: {
                 stubs: {
                     // to better reproduce the legacy snapshot
+                    'b-button': false,
                     'b-dropdown': false,
                     'b-dropdown-item': false,
                     'b-field': false,

--- a/packages/buefy-next/src/components/colorpicker/Colorpicker.vue
+++ b/packages/buefy-next/src/components/colorpicker/Colorpicker.vue
@@ -104,6 +104,7 @@ import { isMobile } from '../../utils/helpers'
 import config from '../../utils/config'
 import Color from '../../utils/color'
 
+import Button from '../button/Button.vue'
 import Dropdown from '../dropdown/Dropdown.vue'
 import DropdownItem from '../dropdown/DropdownItem.vue'
 import Input from '../input/Input.vue'
@@ -137,6 +138,7 @@ export default {
         [Field.name]: Field,
         [Select.name]: Select,
         [Icon.name]: Icon,
+        [Button.name]: Button,
         [Dropdown.name]: Dropdown,
         [DropdownItem.name]: DropdownItem
     },

--- a/packages/buefy-next/src/components/colorpicker/Colorpicker.vue
+++ b/packages/buefy-next/src/components/colorpicker/Colorpicker.vue
@@ -160,6 +160,10 @@ export default {
                     )
             }
         },
+        mobileNative: {
+            type: Boolean,
+            default: true
+        },
         representation: {
             type: String,
             default: 'triangle',

--- a/packages/buefy-next/src/components/colorpicker/Colorpicker.vue
+++ b/packages/buefy-next/src/components/colorpicker/Colorpicker.vue
@@ -164,7 +164,7 @@ export default {
         },
         mobileNative: {
             type: Boolean,
-            default: true
+            default: false
         },
         representation: {
             type: String,

--- a/packages/buefy-next/src/components/colorpicker/__snapshots__/Colorpicker.spec.js.snap
+++ b/packages/buefy-next/src/components/colorpicker/__snapshots__/Colorpicker.spec.js.snap
@@ -3,9 +3,10 @@
 exports[`BColorpicker render correctly 1`] = `
 <div class="colorpicker control">
   <div class="dropdown dropdown-menu-animation is-mobile-modal">
-    <div tabindex="0" class="dropdown-trigger" aria-haspopup="true">
-      <b-button style="background-color: rgb(255, 255, 255); background-size: 100% 100%, 16px 16px, 16px 16px; color: rgb(255, 255, 255); text-shadow: 0 0 2px #000000AA;" expanded="false" disabled="false"><span class="color-name">#00000000</span></b-button>
-    </div>
+    <div tabindex="0" class="dropdown-trigger" aria-haspopup="true"><button class="button" style="background-color: rgb(255, 255, 255); background-size: 100% 100%, 16px 16px, 16px 16px; color: rgb(255, 255, 255); text-shadow: 0 0 2px #000000AA;" type="button">
+        <!--v-if--><span><span class="color-name">#00000000</span></span>
+        <!--v-if-->
+      </button></div>
     <transition-stub name="fade" appear="false" persisted="false" css="true">
       <div class="background" aria-hidden="true" style="display: none;"></div>
     </transition-stub>


### PR DESCRIPTION
Fixes
- fixes #34
- fixes #35

### How to test?
- Build Buef-next with no errors
- Run the dev server and confirm that there are no errors related to #34 in the console anywhere the colorpicker is present 
- Run `npx jest src/components/colorpicker/Colorpicker.spec.js` in the `packages/buefy-next` folder and see no warning is printed