### PR TITLE
Add Missing `BProgress` Import Statement for the `BMessage` Component

### DIFF
--- a/packages/buefy-next/src/components/message/Message.vue
+++ b/packages/buefy-next/src/components/message/Message.vue
@@ -50,9 +50,13 @@
 
 <script>
 import MessageMixin from '../../utils/MessageMixin'
+import Progress from '../progress/Progress.vue'
 
 export default {
     name: 'BMessage',
+    components: {
+        [Progress.name]: Progress
+    },
     mixins: [MessageMixin],
     props: {
         ariaCloseLabel: String


### PR DESCRIPTION
Fixes: #24

### How to test?
- Run the command in the image below:
    `npx jest src/components/message/Message.spec.js`
![image](https://github.com/ntohq/buefy-next/assets/11604664/ce8e2858-3c25-408b-9065-012c4ce5ecf1)
