### PR TITLE
fix(lib): meaningless use(Buefy)

### DIFF
--- a/packages/buefy-next/src/index.js
+++ b/packages/buefy-next/src/index.js
@@ -2,7 +2,7 @@ import * as components from './components'
 
 import { merge } from './utils/helpers'
 import config, { setOptions, setVueInstance } from './utils/config'
-import { use, registerComponentProgrammatic } from './utils/plugins'
+import { registerComponentProgrammatic } from './utils/plugins'
 
 import ConfigComponent from './utils/ConfigComponent'
 
@@ -21,8 +21,6 @@ const Buefy = {
         Vue.config.globalProperties.$buefy.globalNoticeInterval = null
     }
 }
-
-use(Buefy)
 
 export default Buefy
 


### PR DESCRIPTION
Related issue (comment):
- https://github.com/ntohq/buefy-next/issues/221#issuecomment-2057939006

## Proposed Changes

- Remove `use(Buefy)` in the root index file