### PR TITLE
chore: added missing import statement for BIcon in MenuList

### DIFF
--- a/packages/buefy-next/src/components/menu/MenuList.vue
+++ b/packages/buefy-next/src/components/menu/MenuList.vue
@@ -21,8 +21,13 @@
 </template>
 
 <script>
+import Icon from '../icon/Icon.vue'
+
 export default {
     name: 'BMenuList',
+    components: {
+        [Icon.name]: Icon
+    },
     props: {
         label: String,
         icon: String,


### PR DESCRIPTION
Fixes #256 

## Proposed Changes
- Add import `BIcon` import statement to `MenuList` component

### How to test? 
Run the unit test below to confirm that the warning in #256 is no longer present.

```sh
npx jest src/components/menu/MenuList.spec.js
```