### PR TITLE
Fix(docs): extract code snippets in installation folder

### DIFF
--- a/packages/docs/src/pages/installation/ConstructorOptions.vue
+++ b/packages/docs/src/pages/installation/ConstructorOptions.vue
@@ -24,6 +24,11 @@
     import { preformat } from '@/utils'
 
     import api from './api/constructor-options'
+    import {
+        usageBundle,
+        usageCdn,
+        usageComponents,
+    } from './usage/constructor-options'
 
     export default defineComponent({
         components: {
@@ -33,27 +38,9 @@
         data() {
             return {
                 api,
-                usageBundle: `
-                Vue.use(Buefy, {
-                    defaultIconPack: 'fas',
-                    // ...
-                })`,
-                usageComponents: `
-                import { ConfigProgrammatic, Table, Input } from 'buefy'
-
-                Vue.use(Table)
-                Vue.use(Input)
-                ConfigProgrammatic.setOptions({
-                    defaultIconPack: 'fas',
-                    // ...
-                })`,
-                usageCdn: `
-                // When using CDN, Buefy automatically attaches itself on Vue
-                Vue.prototype.$buefy.config.setOptions({
-                    defaultIconPack: 'fas',
-                    // ...
-                })
-                `
+                usageBundle,
+                usageComponents,
+                usageCdn,
             }
         },
         methods: { preformat }

--- a/packages/docs/src/pages/installation/Customization.vue
+++ b/packages/docs/src/pages/installation/Customization.vue
@@ -57,6 +57,11 @@
     import CodeView from '@/components/CodeView.vue'
     import { preformat } from '@/utils'
 
+    import {
+        importing,
+        sass
+    } from './usage/customization'
+
     export default defineComponent({
         components: {
             BMessage,
@@ -64,95 +69,8 @@
         },
         data() {
             return {
-                sass: `
-                // Import Bulma's core
-                @import "~bulma/sass/utilities/_all";
-
-                // Set your colors
-                $primary: #8c67ef;
-                $primary-light: findLightColor($primary);
-                $primary-dark: findDarkColor($primary);
-                $primary-invert: findColorInvert($primary);
-                $twitter: #4099FF;
-                $twitter-invert: findColorInvert($twitter);
-
-                // Lists and maps
-                $custom-colors: null !default;
-                $custom-shades: null !default;
-                
-                // Setup $colors to use as bulma classes (e.g. 'is-twitter')
-                $colors: mergeColorMaps(
-                    (
-                        "white": (
-                            $white,
-                            $black,
-                        ),
-                        "black": (
-                            $black,
-                            $white,
-                        ),
-                        "light": (
-                            $light,
-                            $light-invert,
-                        ),
-                        "dark": (
-                            $dark,
-                            $dark-invert,
-                        ),
-                        "primary": (
-                            $primary,
-                            $primary-invert,
-                            $primary-light,
-                            $primary-dark,
-                        ),
-                        "link": (
-                            $link,
-                            $link-invert,
-                            $link-light,
-                            $link-dark,
-                        ),
-                        "info": (
-                            $info,
-                            $info-invert,
-                            $info-light,
-                            $info-dark,
-                        ),
-                        "success": (
-                            $success,
-                            $success-invert,
-                            $success-light,
-                            $success-dark,
-                        ),
-                        "warning": (
-                            $warning,
-                            $warning-invert,
-                            $warning-light,
-                            $warning-dark,
-                        ),
-                        "danger": (
-                            $danger,
-                            $danger-invert,
-                            $danger-light,
-                            $danger-dark,
-                        ),
-                    ),
-                    $custom-colors
-                );
-
-                // Links
-                $link: $primary;
-                $link-invert: $primary-invert;
-                $link-focus-border: $primary;
-
-                // Import Bulma and Buefy styles
-                @import "~bulma";
-                @import "~buefy/src/scss/buefy";
-                `,
-                importing: `
-                import Vue from 'vue'
-                import Buefy from 'buefy'
-
-                Vue.use(Buefy)`
+                sass,
+                importing
             }
         },
         methods: { preformat }

--- a/packages/docs/src/pages/installation/Start.vue
+++ b/packages/docs/src/pages/installation/Start.vue
@@ -119,6 +119,17 @@
     import CodeView from '@/components/CodeView.vue'
     import { preformat } from '@/utils'
 
+    import {
+        fontAwesome5,
+        importingBundle,
+        importingCDNHtml,
+        importingComponentsAsVuePlugins,
+        importingNuxtBuefy,
+        importingSSR,
+        installNuxtBuefy,
+        materialIcons
+    } from './usage/start'
+
     export default defineComponent({
         components: {
             BMessage,
@@ -126,75 +137,14 @@
         },
         data() {
             return {
-                importingBundle: `
-                import Vue from 'vue'
-                import Buefy from 'buefy'
-                import 'buefy/dist/buefy.css'
-
-                Vue.use(Buefy)
-                `,
-                importingComponentsAsVuePlugins: `
-                import Vue from 'vue'
-                import { Table, Input } from 'buefy'
-                import 'buefy/dist/buefy.css'
-
-                Vue.use(Table)
-                Vue.use(Input)
-                `,
-                importingSSR: `
-                import Vue from 'vue'
-                import Buefy from 'buefy'
-                import 'buefy/dist/buefy.css'
-
-                Vue.use(Buefy) `,
-                installNuxtBuefy: `
-                // with npm
-                npm install nuxt-buefy
-
-                // with yarn
-                yarn add nuxt-buefy
-                `,
-                importingNuxtBuefy: `
-                {
-                    modules: [
-                        // Simple usage
-                        'nuxt-buefy',
-
-                        // Or you can customize
-                        ['nuxt-buefy', { css: false, materialDesignIcons: false }],
-                    ]
-                }`,
-                importingCDNHtml: `
-                <!DOCTYPE html>
-                <html>
-                <head>
-                    <meta charset="utf-8">
-                    <meta name="viewport" content="width=device-width, initial-scale=1">
-                    <link rel="stylesheet" href="https://unpkg.com/buefy/dist/buefy.min.css">
-                </head>
-
-                <body>
-                    <div id="app">
-                        <!-- Buefy components goes here -->
-                    </div>
-
-                    <script src="https://unpkg.com/vue@2"></\script>
-                    <!-- Full bundle -->
-                    <script src="https://unpkg.com/buefy/dist/buefy.min.js"></\script>
-
-                    <!-- Individual components -->
-                    <script src="https://unpkg.com/buefy/dist/components/table"></\script>
-                    <script src="https://unpkg.com/buefy/dist/components/input"></\script>
-
-                    <script>
-                        new Vue({
-                            el: '#app'
-                        })
-                    </\script>
-                </body>
-                </html>`,
-                materialIcons: '<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@5.8.55/css/materialdesignicons.min.css">',
-                fontAwesome5: '<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.2.0/css/all.css">'
+                importingBundle,
+                importingComponentsAsVuePlugins,
+                importingSSR,
+                installNuxtBuefy,
+                importingNuxtBuefy,
+                importingCDNHtml,
+                materialIcons,
+                fontAwesome5
             }
         },
         methods: {

--- a/packages/docs/src/pages/installation/usage/constructor-options.ts
+++ b/packages/docs/src/pages/installation/usage/constructor-options.ts
@@ -1,0 +1,27 @@
+// Code snippets used in the `ConstructorOptions` component.
+//
+// Vite may confuse these examples with the legitimate code and try to compile
+// them, if they are in the component (.vue) file.
+
+export const usageBundle = `
+Vue.use(Buefy, {
+    defaultIconPack: 'fas',
+    // ...
+})`
+
+export const usageComponents = `
+import { ConfigProgrammatic, Table, Input } from 'buefy'
+
+Vue.use(Table)
+Vue.use(Input)
+ConfigProgrammatic.setOptions({
+    defaultIconPack: 'fas',
+    // ...
+})`
+
+export const usageCdn = `
+// When using CDN, Buefy automatically attaches itself on Vue
+Vue.prototype.$buefy.config.setOptions({
+    defaultIconPack: 'fas',
+    // ...
+})`

--- a/packages/docs/src/pages/installation/usage/customization.ts
+++ b/packages/docs/src/pages/installation/usage/customization.ts
@@ -1,0 +1,95 @@
+// Code snippets used in the `Customization` component.
+//
+// Vite may confuse these examples with the legitimate code and try to compile
+// them, if they are in the component (.vue) file.
+
+export const sass = `
+// Import Bulma's core
+@import "~bulma/sass/utilities/_all";
+
+// Set your colors
+$primary: #8c67ef;
+$primary-light: findLightColor($primary);
+$primary-dark: findDarkColor($primary);
+$primary-invert: findColorInvert($primary);
+$twitter: #4099FF;
+$twitter-invert: findColorInvert($twitter);
+
+// Lists and maps
+$custom-colors: null !default;
+$custom-shades: null !default;
+
+// Setup $colors to use as bulma classes (e.g. 'is-twitter')
+$colors: mergeColorMaps(
+    (
+        "white": (
+            $white,
+            $black,
+        ),
+        "black": (
+            $black,
+            $white,
+        ),
+        "light": (
+            $light,
+            $light-invert,
+        ),
+        "dark": (
+            $dark,
+            $dark-invert,
+        ),
+        "primary": (
+            $primary,
+            $primary-invert,
+            $primary-light,
+            $primary-dark,
+        ),
+        "link": (
+            $link,
+            $link-invert,
+            $link-light,
+            $link-dark,
+        ),
+        "info": (
+            $info,
+            $info-invert,
+            $info-light,
+            $info-dark,
+        ),
+        "success": (
+            $success,
+            $success-invert,
+            $success-light,
+            $success-dark,
+        ),
+        "warning": (
+            $warning,
+            $warning-invert,
+            $warning-light,
+            $warning-dark,
+        ),
+        "danger": (
+            $danger,
+            $danger-invert,
+            $danger-light,
+            $danger-dark,
+        ),
+    ),
+    $custom-colors
+);
+
+// Links
+$link: $primary;
+$link-invert: $primary-invert;
+$link-focus-border: $primary;
+
+// Import Bulma and Buefy styles
+@import "~bulma";
+@import "~buefy/src/scss/buefy";
+`
+
+export const importing = `
+import Vue from 'vue'
+import Buefy from 'buefy'
+
+Vue.use(Buefy)`

--- a/packages/docs/src/pages/installation/usage/start.ts
+++ b/packages/docs/src/pages/installation/usage/start.ts
@@ -1,0 +1,81 @@
+// Code snippets used in the `Start` component.
+//
+// Vite may confuse these examples with the legitimate code and try to compile
+// them, if they are in the component (.vue) file.
+
+export const importingBundle = `
+import Vue from 'vue'
+import Buefy from 'buefy'
+import 'buefy/dist/buefy.css'
+
+Vue.use(Buefy)
+`
+
+export const importingComponentsAsVuePlugins = `
+import Vue from 'vue'
+import { Table, Input } from 'buefy'
+import 'buefy/dist/buefy.css'
+
+Vue.use(Table)
+Vue.use(Input)
+`
+
+export const importingSSR = `
+import Vue from 'vue'
+import Buefy from 'buefy'
+import 'buefy/dist/buefy.css'
+
+Vue.use(Buefy) `
+
+export const installNuxtBuefy = `
+// with npm
+npm install nuxt-buefy
+
+// with yarn
+yarn add nuxt-buefy
+`
+
+export const importingNuxtBuefy = `
+{
+    modules: [
+        // Simple usage
+        'nuxt-buefy',
+
+        // Or you can customize
+        ['nuxt-buefy', { css: false, materialDesignIcons: false }],
+    ]
+}`
+
+export const importingCDNHtml = `
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="https://unpkg.com/buefy/dist/buefy.min.css">
+</head>
+
+<body>
+    <div id="app">
+        <!-- Buefy components goes here -->
+    </div>
+
+    <script src="https://unpkg.com/vue@2"></\script>
+    <!-- Full bundle -->
+    <script src="https://unpkg.com/buefy/dist/buefy.min.js"></\script>
+
+    <!-- Individual components -->
+    <script src="https://unpkg.com/buefy/dist/components/table"></\script>
+    <script src="https://unpkg.com/buefy/dist/components/input"></\script>
+
+    <script>
+        new Vue({
+            el: '#app'
+        })
+    </\script>
+</body>
+</html>`
+
+export const materialIcons = '<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@5.8.55/css/materialdesignicons.min.css">'
+
+export const fontAwesome5 = '<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.2.0/css/all.css">'


### PR DESCRIPTION
Fixes:
- The problem that the docs dev server did not start. See the [comment](https://github.com/ntohq/buefy-next/pull/294#issuecomment-2543350544) on the PR #294

## Proposed Changes

- Moves code examples from component (.vue) files to dedicated TypeScript files so that Vite won't confuse them with actual code and try to compile them