### PR TITLE
Most obvious of TypeScript definitions for app.use(Buefy)

### DIFF
--- a/packages/buefy-next/src/types/components.d.ts
+++ b/packages/buefy-next/src/types/components.d.ts
@@ -1,4 +1,4 @@
-import _Vue from "vue";
+import _Vue, { Component } from "vue";
 import {ColorModifiers, DaysOfWeek, GlobalPositions, SizesModifiers} from "./helpers";
 
 // Component base definition
@@ -10,7 +10,7 @@ export class BComponent extends _Vue {
 export declare type BuefyConfig = {
     defaultContainerElement?: string,
     defaultIconPack?: string;
-    defaultIconComponent?: string;
+    defaultIconComponent?: Component;
     defaultIconPrev?: string;
     defaultIconNext?: string;
     defaultLocale?: undefined | string | string[],

--- a/packages/buefy-next/src/types/index.d.ts
+++ b/packages/buefy-next/src/types/index.d.ts
@@ -23,12 +23,11 @@ export declare type BuefyNamespace = {
     modal: typeof ModalProgrammatic,
     snackbar: typeof SnackbarProgrammatic,
     toast: typeof ToastProgrammatic,
-    notification: typeof NotificationProgrammatic
-
+    notification: typeof NotificationProgrammatic,
 }
 
 declare const _default: {
-    install(Vue: typeof _Vue, config: BuefyConfig): void;
+    install(Vue: _Vue, config: BuefyConfig): void;
 };
 
 export {


### PR DESCRIPTION
Currently activating buefy-next in a TypeScript enabled project results in:

![image](https://github.com/user-attachments/assets/ad9fdfc8-e73e-45c8-b08b-6eb3b3b57a2f)

This PR changes the argument type of the plugin installer to fix that, along with a glaring error in the `BuefyConfig` definition. I'm sure there is much more typing work to be done, but this at least supports a basic install.
