### PR TITLE
Fix: Cannot find module @rollup/rollup-linux-x64-gnu (#322)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2745,6 +2745,18 @@
         "darwin"
       ]
     },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.6.1.tgz",
+      "integrity": "sha512-DNGZvZDO5YF7jN5fX8ZqmGLjZEXIJRdJEdTFMhiyXqyXubBa0WVLDWSNlQ5JR2PNgDbEV1VQowhVRUh+74D+RA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@rushstack/node-core-library": {
       "version": "5.5.0",
       "dev": true,
@@ -11374,6 +11386,9 @@
         "rollup": "^4.1.4",
         "rollup-plugin-esbuild": "^6.1.0",
         "vitest": "^0.34.6"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "4.6.1"
       },
       "peerDependencies": {
         "vue": "^3.0.0"

--- a/packages/buefy-next/package.json
+++ b/packages/buefy-next/package.json
@@ -72,5 +72,8 @@
     "rollup": "^4.1.4",
     "rollup-plugin-esbuild": "^6.1.0",
     "vitest": "^0.34.6"
+  },
+  "optionalDependencies": {
+    "@rollup/rollup-linux-x64-gnu": "4.6.1"
   }
 }


### PR DESCRIPTION
- fixes #322

## Proposed Changes

- Adds `@rollup/rollup-linux-x64-gnu` to `optionalDependencies`. The version is fixed to 4.6.1 because the current version of `rollup` recorded in `package-lock.json` is 4.6.1.