### PR TITLE
TypeScript Rollout Tier 4 - ConfigComponent (#303)

### DIFF
--- a/packages/buefy-next/rollup.config.mjs
+++ b/packages/buefy-next/rollup.config.mjs
@@ -77,7 +77,7 @@ const JS_COMPONENTS = [
 const entries = {
     index: './src/index.ts',
     helpers: './src/utils/helpers.ts',
-    config: './src/utils/ConfigComponent.js',
+    config: './src/utils/ConfigComponent.ts',
     ...components.reduce((obj, name) => {
         const ext = JS_COMPONENTS.indexOf(name) !== -1 ? 'js' : 'ts'
         obj[name] = (baseFolder + componentsFolder + name + `/index.${ext}`)

--- a/packages/buefy-next/src/utils/ConfigComponent.ts
+++ b/packages/buefy-next/src/utils/ConfigComponent.ts
@@ -1,11 +1,12 @@
 import config, { setOptions } from './config'
+import type { BuefyConfigOptions } from './config'
 import { merge } from './helpers'
 
 export default {
     getOptions() {
         return config
     },
-    setOptions(options) {
+    setOptions(options: BuefyConfigOptions) {
         setOptions(merge(config, options, true))
     }
 }

--- a/packages/buefy-next/src/utils/vue-augmentation.ts
+++ b/packages/buefy-next/src/utils/vue-augmentation.ts
@@ -7,6 +7,8 @@
 // otherwise the post processing will be messed up.
 import 'vue'
 
+import ConfigComponent from './ConfigComponent'
+
 // Augments the global property with `$buefy`.
 // https://vuejs.org/guide/typescript/options-api.html#augmenting-global-properties
 declare module '@vue/runtime-core' {
@@ -14,6 +16,7 @@ declare module '@vue/runtime-core' {
     interface ComponentCustomProperties {
         /** Global Buefy API. */
         $buefy: {
+            config: typeof ConfigComponent,
             globalNoticeInterval?: ReturnType<typeof setTimeout>,
             // TODO: make key-values more specific
             // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Related issues:
- #151
- #303

## Proposed Changes

- Migration of `utils/ConfigComponent`
  - Adds `config` to the global property `$buefy`
  - Modifies `packages/buefy-next/rollup.config.mjs`