### PR TITLE
TypeScript Rollout Tier 4 - fix NoticeMixin import path

### DIFF
--- a/packages/buefy-next/src/components/notification/NoticeMixinSubset.js
+++ b/packages/buefy-next/src/components/notification/NoticeMixinSubset.js
@@ -1,4 +1,4 @@
-import NoticeMixin from '../../utils/NoticeMixin.js'
+import NoticeMixin from '../../utils/NoticeMixin'
 
 // drops props not used by `NoticeMixin` itself
 // - type


### PR DESCRIPTION
- closes #303

## Proposed Changes

- Fixes the import path of `NoticeMixin` in `notification/NoticeMixinSubset`