### PR TITLE
Add --prefer-offline to npm ci in verify.yml

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
 
-      - run: npm ci
+      - run: npm ci --prefer-offline
 
       - name: Lint
         # skips until the TypeScript migration is complete
@@ -69,7 +69,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
 
-      - run: npm ci
+      - run: npm ci --prefer-offline
 
       - name: Lint docs
         # skips until the TypeScript migration is complete


### PR DESCRIPTION
Related issue:
- Fixes #364

## Proposed Changes

- Adds the `--prefer-offline` option to `npm ci` commands in the `verify.yml` workflow to reduce network traffic.