### PR TITLE
TypeScript Rollout Tier 11 - wrap-up of the lib part

### DIFF
--- a/packages/buefy-next/rollup.config.mjs
+++ b/packages/buefy-next/rollup.config.mjs
@@ -29,16 +29,12 @@ const components = fs
         fs.statSync(path.join(baseFolder + componentsFolder, f)).isDirectory()
     )
 
-const JS_COMPONENTS = [
-]
-
 const entries = {
     index: './src/index.ts',
     helpers: './src/utils/helpers.ts',
     config: './src/utils/ConfigComponent.ts',
     ...components.reduce((obj, name) => {
-        const ext = JS_COMPONENTS.indexOf(name) !== -1 ? 'js' : 'ts'
-        obj[name] = (baseFolder + componentsFolder + name + `/index.${ext}`)
+        obj[name] = (baseFolder + componentsFolder + name + `/index.ts`)
         return obj
     }, {})
 }
@@ -65,10 +61,9 @@ const esbuildConfig = {
 
 export default () => {
     const mapComponent = (name) => {
-        const ext = JS_COMPONENTS.indexOf(name) !== -1 ? 'js' : 'ts'
         return [
             {
-                input: baseFolder + componentsFolder + `${name}/index.${ext}`,
+                input: baseFolder + componentsFolder + `${name}/index.ts`,
                 external: ['vue'],
                 output: {
                     format: 'umd',

--- a/packages/buefy-next/src/utils/plugins.ts
+++ b/packages/buefy-next/src/utils/plugins.ts
@@ -26,9 +26,10 @@ export const registerComponent = (Vue: App, component: Component, name?: string)
     Vue.component(componentName, component)
 }
 
-// TODO: refine the type of `component`.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const registerComponentProgrammatic = (Vue: App, property: string, component: any) => {
+export const registerComponentProgrammatic = <
+    K extends keyof App['config']['globalProperties']['$buefy'],
+    C extends App['config']['globalProperties']['$buefy'][K]
+>(Vue: App, property: K, component: C) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     if (!Vue.config.globalProperties.$buefy) Vue.config.globalProperties.$buefy = {} as any
     Vue.config.globalProperties.$buefy[property] = component

--- a/packages/buefy-next/src/utils/plugins.ts
+++ b/packages/buefy-next/src/utils/plugins.ts
@@ -1,20 +1,4 @@
-import type { App, Component, Plugin } from 'vue'
-
-// TODO: `use` shall be removed and this declaration shall also be removed.
-declare global {
-    interface Window {
-        Vue?: App
-    }
-}
-
-// same signature as `App.use`: https://github.com/vuejs/core/blob/ee4cd78a06e6aa92b12564e527d131d1064c2cd0/packages/runtime-core/src/apiCreateApp.ts#L36-L39
-// TODO: `use` no longer makes sense in Vue 3.
-export const use: <T extends unknown[]>(plugin: Plugin<T>, ...options: T) => void =
-    (plugin, ...options) => {
-        if (typeof window !== 'undefined' && window.Vue) {
-            window.Vue.use(plugin, options)
-        }
-    }
+import type { App, Component } from 'vue'
 
 // use `name` to register a Functional Component which will become unresolvable
 // in production build due to name mangling.

--- a/packages/buefy-next/src/utils/vue-augmentation.ts
+++ b/packages/buefy-next/src/utils/vue-augmentation.ts
@@ -29,10 +29,7 @@ declare module '@vue/runtime-core' {
             modal: ModalProgrammatic,
             notification: NotificationProgrammatic,
             snackbar: SnackbarProgrammatic,
-            toast: ToastProgrammatic,
-            // TODO: make key-values more specific
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            [key: string]: any
+            toast: ToastProgrammatic
         }
     }
 }

--- a/packages/buefy-next/tsconfig.json
+++ b/packages/buefy-next/tsconfig.json
@@ -4,7 +4,6 @@
   "exclude": ["node_modules", "src/scss/*", "src/**/*.spec.*"],
   "compilerOptions": {
     "types": ["jsdom"],
-    "allowJs": true,
     "declaration": false
   }
 }

--- a/packages/buefy-next/tsconfig.types.json
+++ b/packages/buefy-next/tsconfig.types.json
@@ -4,7 +4,6 @@
     "composite": true,
     "rootDir": "./src",
     "noEmit": false,
-    "allowJs": true,
     "declaration": true,
     "emitDeclarationOnly": true,
     "stripInternal": true,


### PR DESCRIPTION
Related issues:
- #151
- closes #310

## Proposed Changes

- The `$buefy` global property no longer allows anonymous fields.
- The `registerComponentProgrammatic` utility function becomes type-safe.
- The legacy global Vue object, and the `use` utility function are removed.
- `rollup.config.mjs` no longer processes .js files.
- The TypeScript configs no longer allow .js files.