### PR TITLE
TypeScript Rollout Tier 12 - docs data

### DIFF
--- a/packages/docs/src/data/expo.ts
+++ b/packages/docs/src/data/expo.ts
@@ -1,0 +1,11 @@
+import expo from './expo.json'
+
+export interface ExpoInfo {
+    title: string
+    date: string
+    img: string
+    url: string
+    featured?: boolean
+}
+
+export default expo as ExpoInfo[]

--- a/packages/docs/src/data/menu.ts
+++ b/packages/docs/src/data/menu.ts
@@ -1,0 +1,8 @@
+import menu from './menu.json'
+
+export interface PageTree {
+    category: string
+    pages: (PageTree | string)[]
+}
+
+export default menu as Record<string, PageTree[]>

--- a/packages/docs/src/data/routes.ts
+++ b/packages/docs/src/data/routes.ts
@@ -1,0 +1,16 @@
+import routes from './routes.json'
+
+export interface Route {
+    title: string
+    subtitle: string
+    breadTitle?: string
+    path: string
+    githubPath?: string
+    menu?: string
+    breadcrumb?: string[]
+    isUpdated?: boolean
+    isNew?: boolean
+    hideSidebar?: boolean
+}
+
+export default routes as Record<string, Route>

--- a/packages/docs/src/data/sponsors.ts
+++ b/packages/docs/src/data/sponsors.ts
@@ -1,0 +1,9 @@
+import sponsors from './sponsors.json'
+
+export interface SponsorInfo {
+    title: string
+    url: string
+    img: string
+}
+
+export default sponsors as SponsorInfo[]


### PR DESCRIPTION
Related issues:
- #151
- closes #311

## Proposed Changes

- Augments the JSON files in `packages/docs/src/data/` with the schemas in TypeScript