### PR TITLE
Bundle MIT License in NPM Package 

### DIFF
--- a/packages/buefy-next/LICENSE.md
+++ b/packages/buefy-next/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017-2024 [these people](https://github.com/buefy/buefy/graphs/contributors)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Fixes #276

## Proposed Changes
- Copy the Buefy MIT license to the root of the buefy-next package workspace.

### How to test?
1. Checkout the `BundleLicense` branch.
2. cd to the buefy-next workspace.
3. Run `npm i`
4. Run `npm pack`
5. Make a temp directory (`mkdir tmp`)
6. Move the newly generate `tgz` file to the tmp directory.
7. Extract its contents into the tmp folder using tar.
8. open the newly created packages folder.
9. You should see LICENSE.md with in that bundled package.

### Testing Evidence
![image](https://github.com/user-attachments/assets/abb335bd-f216-40fc-b384-6c54efdc6488)


