### PR TITLE
Bump version to 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Buefy Changelog
 
+## Buefy-next 0.2.1 unreleased
+
 ## Buefy-next 0.2.0
 
 ### New features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "root",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "root",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -11362,7 +11362,7 @@
     },
     "packages/buefy-next": {
       "name": "@ntohq/buefy-next",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/plugin-transform-runtime": "^7.23.2",
@@ -11462,7 +11462,7 @@
       }
     },
     "packages/docs": {
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@ntohq/buefy-next": "*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "root",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "homepage": "https://buefy.org",
   "description": "Lightweight UI components for Vue.js (v3) based on Bulma",
   "license": "MIT",

--- a/packages/buefy-next/package.json
+++ b/packages/buefy-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ntohq/buefy-next",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Lightweight UI components for Vue.js (v3) based on Bulma",
   "keywords": [
     "vuejs",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "author": "Rafael Beraldo <rafael.pimpa@gmail.com>",
   "homepage": "htps://buefy.org",


### PR DESCRIPTION
No related issue.

## Proposed Changes

- Bumps version to 0.2.1 so that developer releases will be published with proper version.
- Adds a section for 0.2.1 to `CHANGELOG.md` so that we can start recording changes to it.