### PR TITLE
Fix: [Numberinput] Validation may not work with Vue 3.4.28 or higher #429

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#274](https://github.com/ntohq/buefy-next/issues/274) `Table`, and `Tabs` caused memory leaks on Vue 3.5.
   `SlotComponent` which is internally used by `Table`, and `Tabs` ceased adding the update hook to the component specified to the `component` prop, and dropped the `event` prop.
+* [#429](https://github.com/ntohq/buefy-next/issues/429) `Numberinput` may have accepted an invalid number as valid with Vue 3.4.28 or higher.
 
 ## Buefy-next 0.2.0
 

--- a/packages/buefy-next/src/components/input/Input.vue
+++ b/packages/buefy-next/src/components/input/Input.vue
@@ -4,35 +4,68 @@
         :class="rootClasses"
         v-bind="rootAttrs"
     >
-        <input
-            v-if="type !== 'textarea'"
-            ref="input"
-            class="input"
-            :class="[inputClasses, customClass]"
-            :type="newType"
-            :autocomplete="newAutocomplete"
-            :maxlength="maxlength"
-            :value="computedValue"
-            v-bind="fallthroughAttrs"
-            @input="onInput"
-            @change="onChange"
-            @blur="onBlur"
-            @focus="onFocus"
-        >
+        <template v-if="lazy">
+            <input
+                v-if="type !== 'textarea'"
+                ref="input"
+                class="input"
+                :class="[inputClasses, customClass]"
+                :type="newType"
+                :autocomplete="newAutocomplete"
+                :maxlength="maxlength"
+                v-model.lazy="computedValue"
+                v-bind="fallthroughAttrs"
+                @input="onInput"
+                @change="onChange"
+                @blur="onBlur"
+                @focus="onFocus"
+            >
 
-        <textarea
-            v-else
-            ref="textarea"
-            class="textarea"
-            :class="[inputClasses, customClass]"
-            :maxlength="maxlength"
-            :value="computedValue === null ? undefined : computedValue"
-            v-bind="fallthroughAttrs"
-            @input="onInput"
-            @change="onChange"
-            @blur="onBlur"
-            @focus="onFocus"
-        />
+            <textarea
+                v-else
+                ref="textarea"
+                class="textarea"
+                :class="[inputClasses, customClass]"
+                :maxlength="maxlength"
+                v-model.lazy="computedValue"
+                v-bind="fallthroughAttrs"
+                @input="onInput"
+                @change="onChange"
+                @blur="onBlur"
+                @focus="onFocus"
+            />
+        </template>
+        <template v-else>
+            <input
+                v-if="type !== 'textarea'"
+                ref="input"
+                class="input"
+                :class="[inputClasses, customClass]"
+                :type="newType"
+                :autocomplete="newAutocomplete"
+                :maxlength="maxlength"
+                v-model="computedValue"
+                v-bind="fallthroughAttrs"
+                @input="onInput"
+                @change="onChange"
+                @blur="onBlur"
+                @focus="onFocus"
+            >
+
+            <textarea
+                v-else
+                ref="textarea"
+                class="textarea"
+                :class="[inputClasses, customClass]"
+                :maxlength="maxlength"
+                v-model="computedValue"
+                v-bind="fallthroughAttrs"
+                @input="onInput"
+                @change="onChange"
+                @blur="onBlur"
+                @focus="onFocus"
+            />
+        </template>
 
         <b-icon
             v-if="icon"
@@ -282,22 +315,19 @@ export default defineComponent({
             }
         },
 
-        onInput(event: Event) {
+        onInput() {
             if (!this.lazy) {
-                const value = (event.target as HTMLInputElement | HTMLTextAreaElement).value
-                this.updateValue(value)
+                this.revalidate()
             }
         },
 
-        onChange(event: Event) {
+        onChange() {
             if (this.lazy) {
-                const value = (event.target as HTMLInputElement | HTMLTextAreaElement).value
-                this.updateValue(value)
+                this.revalidate()
             }
         },
 
-        updateValue(value: string | number | undefined) {
-            this.computedValue = value
+        revalidate() {
             !this.isValid && this.checkHtml5Validity()
         }
     }


### PR DESCRIPTION
- fixes #429
- closes #431

## Proposed Changes

- Fixes the issues that `Numberinput` may have accepted an invalid user input without a validation error on Vue 3.4.28 or higher.
  - To work around an upstream issue introduced in Vue 3.4.28, the underlying `Input` component uses `v-model` instead of the combination of the `:value` binding, and `@input` and `@change` event handlers. See "Background" for more details.
  - Please note that this PR will cause type errors regarding the `v-model` bindings in `<textarea>`. However, the **type errors will be fixed if we upgrade Vue to 3.4.6 or higher**.
- More comprehensively tests the `lazy` prop of `Input`.

### Background

`Numberinput` should reject numbers which are not equal to the basis for stepping, and the basis is derived from the `value` attribute unless the `min` is given. Before Vue 3.4.28, updating the `value` prop did not affect the `value` attribute, however, Vue 3.4.28 or higher introduced a [tweak that updates the `value` attribute when the `value` prop is
changed](https://github.com/vuejs/core/commit/537a571f8cf09dfe0a020e9e8891ecdd351fc3e4#diff-51bf3d2247157ea7e415bdcf74feabbe5843467638c131743785ab6c68640605R58). Since the `value` attribute which defines the basis moves, the validation of `Numberinput` can be messed up. The problematic tweak is not applied to `v-model` which the underlying `Input` did not use.

The reason why `Input` did not use `v-model` was to deal with the `lazy` prop. While `v-model` needs an optional `.lazy` modifier if the `lazy` prop is `true`, unfortunately, we cannot dynamically turn on / off the `.lazy` modifier on `v-model`. (`modelModifiers` prop won't work with `.lazy` modifier.) This is why I had to duplicate the `<input>` and
`<textarea>` elements.