### PR TITLE
Fix: [Table] Sort multiple example does not work #434

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Buefy-next 0.2.1 is now compiled with Vue 3.4.13, so the recommended Vue version
 * [#274](https://github.com/ntohq/buefy-next/issues/274) `Table`, and `Tabs` caused memory leaks on Vue 3.5.
   `SlotComponent` which is internally used by `Table`, and `Tabs` ceased adding the update hook to the component specified to the `component` prop, and dropped the `event` prop.
 * [#429](https://github.com/ntohq/buefy-next/issues/429) `Numberinput` may have accepted an invalid number as valid with Vue 3.4.28 or higher.
+* [#434](https://github.com/ntohq/buefy-next/issues/434) The multi column sorting feature of `Table` did not work since Buefy-next v0.2.0.
 
 ### Others
 

--- a/packages/buefy-next/src/components/table/TableMobileSort.vue
+++ b/packages/buefy-next/src/components/table/TableMobileSort.vue
@@ -55,7 +55,7 @@
                         @click="sort"
                     >
                         <b-icon
-                            :class="{ 'is-desc': columnIsDesc(sortMultipleSelect!) }"
+                            :class="{ 'is-desc': columnIsDesc(sortMultipleSelect) }"
                             :icon="sortIcon"
                             :pack="iconPack"
                             :size="sortIconSize"
@@ -214,8 +214,8 @@ export default defineComponent({
             return this.sortMultipleData!.filter((i) =>
                 i.field === column.field)[0]
         },
-        columnIsDesc(column: ITableColumn) {
-            const sortingObject = this.getSortingObjectOfColumn(column)
+        columnIsDesc(column: ITableColumn | null) {
+            const sortingObject = column && this.getSortingObjectOfColumn(column)
             if (sortingObject) {
                 return !!(sortingObject.order && sortingObject.order === 'desc')
             }


### PR DESCRIPTION
Fixes
- fixes #434

## Proposed Changes

- Fixes a `null` reference error introduced during the TypeScript migration.
  - The bug was triggered because I changed the initial value of the `sortMultipleSelect` data field from an empty string to `null`. As reverting the change will end up with a type error, I add an additional `null` check to fix the error instead.