### PR TITLE
Fix: Flaky test of Autocomplete (#403)

### DIFF
--- a/packages/buefy-next/src/components/autocomplete/Autocomplete.vue
+++ b/packages/buefy-next/src/components/autocomplete/Autocomplete.vue
@@ -606,7 +606,7 @@ export default defineComponent({
                 const rect = (this.$refs.dropdown as Element).getBoundingClientRect()
 
                 this.isListInViewportVertically = rect.top >= 0 &&
-                    rect.bottom <= (window.innerHeight || document.documentElement.clientHeight)
+                    rect.bottom <= (window?.innerHeight || document?.documentElement?.clientHeight)
                 if (this.appendToBody) {
                     this.updateAppendToBody()
                 }


### PR DESCRIPTION
- fixes #403

## Proposed Changes

- Works around the issue that the Autocomplete test was flaky. The error was caused because the callback given to `$nextTick` was somehow called after the component was detached and ended up with referencing `window=undefined`. Applies optional chaining (`?`) to `window` and `document` to be prepared for `undefined`.