### PR TITLE
Fix Rollup Build Errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
         "vue-tsc": "^2.2.2"
       },
       "optionalDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "^4.34.8"
+        "@rollup/rollup-linux-x64-gnu": "^4.34.8",
+        "@rollup/rollup-win32-x64-msvc": "^4.40.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -3271,13 +3272,13 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.34.8.tgz",
-      "integrity": "sha512-U0FaE5O1BCpZSeE6gBl3c5ObhePQSfk9vDRToMmTkbhCOgW4jqvtS5LGyQ76L1fH8sM0keRp4uDTsbjiUyjk0g==",
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.40.0.tgz",
+      "integrity": "sha512-lpPE1cLfP5oPzVjKMx10pgBmKELQnFJXHgvtHCtuJWOv8MxqdEIMNtgHgBFf7Ea2/7EuVwa9fodWUfXAlXZLZQ==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -9239,6 +9240,20 @@
         "esbuild": ">=0.18.0",
         "rollup": "^1.20.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
       }
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.34.8.tgz",
+      "integrity": "sha512-U0FaE5O1BCpZSeE6gBl3c5ObhePQSfk9vDRToMmTkbhCOgW4jqvtS5LGyQ76L1fH8sM0keRp4uDTsbjiUyjk0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "vue-tsc": "^2.2.2"
   },
   "optionalDependencies": {
-    "@rollup/rollup-linux-x64-gnu": "^4.34.8"
+    "@rollup/rollup-linux-x64-gnu": "^4.34.8",
+    "@rollup/rollup-win32-x64-msvc": "^4.40.0"
   },
   "repository": {
     "type": "git",

--- a/packages/buefy-next/rollup.config.mjs
+++ b/packages/buefy-next/rollup.config.mjs
@@ -8,7 +8,7 @@ import vue from '@vitejs/plugin-vue'
 import fs from 'node:fs'
 import path from 'node:path'
 
-import pack from '../../package.json' assert { type: 'json' }
+import pack from '../../package.json' with { type: "json" }
 
 const babelConfig = {
     exclude: 'node_modules/**',

--- a/packages/buefy-next/rollup.config.mjs
+++ b/packages/buefy-next/rollup.config.mjs
@@ -8,7 +8,7 @@ import vue from '@vitejs/plugin-vue'
 import fs from 'node:fs'
 import path from 'node:path'
 
-import pack from '../../package.json' with { type: "json" }
+import pack from '../../package.json' with { type: 'json' }
 
 const babelConfig = {
     exclude: 'node_modules/**',


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes [#450](https://github.com/ntohq/buefy-next/issues/450), [#451](https://github.com/ntohq/buefy-next/issues/451)

## Proposed Changes

- Use the keyword `with` instead of `assert` when importing the json (Supported by Node 18 and up)
- Add the windows msvc rollup package to allow developers using windows to compile buefy
