### PR TITLE
Fix Build TS Definition Warnings

### DIFF
--- a/packages/buefy-next/api-extractor.json
+++ b/packages/buefy-next/api-extractor.json
@@ -393,7 +393,7 @@
       "default": {
         "logLevel": "warning"
         // "addToApiReportFile": false
-      }
+      },
 
       // "ae-extra-release-tag": {
       //   "logLevel": "warning",
@@ -401,6 +401,12 @@
       // },
       //
       // . . .
+      "ae-forgotten-export": {
+          "logLevel": "none" // Suppress forgotten export warnings
+      },
+      "ae-missing-release-tag": {
+          "logLevel": "none" // Suppress missing release tag warnings
+      }
     },
 
     /**

--- a/packages/buefy-next/src/components/dialog/Dialog.vue
+++ b/packages/buefy-next/src/components/dialog/Dialog.vue
@@ -255,14 +255,14 @@ const Dialog = defineComponent({
             }, 150)
         },
 
-        /**
+        /*
         * Start the Loading.
         */
         startLoading() {
             this.isLoading = true
         },
 
-        /**
+        /*
         * Cancel the Loading.
         */
         cancelLoading() {

--- a/packages/buefy-next/src/components/field/Field.vue
+++ b/packages/buefy-next/src/components/field/Field.vue
@@ -73,21 +73,21 @@ import config from '../../utils/config'
 import { isTag } from '../../utils/helpers'
 import BFieldBody from './FieldBody.vue'
 
-/**
+/*
  * Type of the `type` prop of `BField`.
  *
  * @public
  */
 export type FieldTypeProp = string | Record<string, boolean>
 
-/**
+/*
  * Type of individual message items in the `message` prop of `BField`.
  *
  * @public
  */
 export type FieldMessagePropItem = string | Record<string, string>
 
-/**
+/*
  * Type of the `message` prop of `BField`.
  *
  * @public

--- a/packages/buefy-next/src/components/icon/Icon.vue
+++ b/packages/buefy-next/src/components/icon/Icon.vue
@@ -47,7 +47,7 @@ export default defineComponent({
             }
             return ''
         },
-        /**
+        /*
         * Internal icon name based on the pack.
         * If pack is 'fa', gets the equivalent FA icon name of the MDI,
         * internal icons are always MDI.
@@ -95,7 +95,7 @@ export default defineComponent({
         }
     },
     methods: {
-        /**
+        /*
         * Equivalent icon name of the MDI.
         */
         getEquivalentIconOf(value: string) {

--- a/packages/buefy-next/src/components/image/Image.vue
+++ b/packages/buefy-next/src/components/image/Image.vue
@@ -75,7 +75,7 @@ function isBulmaKnownRatio(value: unknown): value is BulmaKnownRatio {
     return BULMA_KNOWN_RATIO.indexOf(value as BulmaKnownRatio) !== -1
 }
 
-/** Type of the `srcsetFormatter` prop. */
+/* Type of the `srcsetFormatter` prop. */
 export type SrcsetFormatter = (
     src: string,
     size: number,

--- a/packages/buefy-next/src/components/input/Input.vue
+++ b/packages/buefy-next/src/components/input/Input.vue
@@ -207,7 +207,7 @@ export default defineComponent({
             return this.statusType
         },
 
-        /**
+        /*
         * Position of the icon or if it's both sides.
         */
         iconPosition() {

--- a/packages/buefy-next/src/components/progress/Progress.vue
+++ b/packages/buefy-next/src/components/progress/Progress.vue
@@ -116,7 +116,7 @@ const Progress = defineComponent({
         }
     },
     watch: {
-        /**
+        /*
          * When value is changed back to undefined, value of native progress get reset to 0.
          * Need to add and remove the value attribute to have the indeterminate or not.
          */

--- a/packages/buefy-next/src/components/snackbar/Snackbar.vue
+++ b/packages/buefy-next/src/components/snackbar/Snackbar.vue
@@ -71,7 +71,7 @@ const Snackbar = defineComponent({
         }
     },
     methods: {
-        /**
+        /*
         * Click listener.
         * Call action prop before closing (from Mixin).
         */

--- a/packages/buefy-next/src/components/steps/Steps.vue
+++ b/packages/buefy-next/src/components/steps/Steps.vue
@@ -172,14 +172,14 @@ export default defineComponent({
             ]
         },
 
-        /**
+        /*
          * Check if previous button is available.
          */
         hasPrev() {
             return this.prevItemIdx !== null
         },
 
-        /**
+        /*
          * Retrieves the next visible item index
          */
         nextItemIdx() {
@@ -187,7 +187,7 @@ export default defineComponent({
             return this.getNextItemIdx(idx)
         },
 
-        /**
+        /*
          * Retrieves the next visible item
          */
         nextItem() {
@@ -198,7 +198,7 @@ export default defineComponent({
             return nextItem
         },
 
-        /**
+        /*
         * Retrieves the next visible item index
         */
         prevItemIdx() {
@@ -207,7 +207,7 @@ export default defineComponent({
             return this.getPrevItemIdx(idx)
         },
 
-        /**
+        /*
          * Retrieves the previous visible item
          */
         prevItem() {
@@ -220,7 +220,7 @@ export default defineComponent({
             return prevItem
         },
 
-        /**
+        /*
          * Check if next button is available.
          */
         hasNext() {
@@ -241,7 +241,7 @@ export default defineComponent({
         }
     },
     methods: {
-        /**
+        /*
          * Return if the step should be clickable or not.
          */
         isItemClickable(stepItem: IStepItem) {
@@ -251,7 +251,7 @@ export default defineComponent({
             return stepItem.clickable
         },
 
-        /**
+        /*
          * Previous button click listener.
          */
         prev() {
@@ -260,7 +260,7 @@ export default defineComponent({
             }
         },
 
-        /**
+        /*
          * Previous button click listener.
          */
         next() {

--- a/packages/buefy-next/src/components/switch/Switch.vue
+++ b/packages/buefy-next/src/components/switch/Switch.vue
@@ -125,7 +125,7 @@ const Switch = defineComponent({
         }
     },
     watch: {
-        /**
+        /*
         * When v-model change, set internal value.
         */
         modelValue(value) {

--- a/packages/buefy-next/src/components/table/TableColumn.vue
+++ b/packages/buefy-next/src/components/table/TableColumn.vue
@@ -98,7 +98,7 @@ export default defineComponent({
         hasDefaultSlot() {
             return !!this.$slots.default
         },
-        /**
+        /*
          * Return if column header is un-selectable
          */
         isHeaderUnSelectable() {

--- a/packages/buefy-next/src/components/tag/Tag.vue
+++ b/packages/buefy-next/src/components/tag/Tag.vue
@@ -110,7 +110,7 @@ export default defineComponent({
         }
     },
     methods: {
-        /**
+        /*
         * Emit close event when delete button is clicked
         * or delete key is pressed.
         */
@@ -119,7 +119,7 @@ export default defineComponent({
 
             this.$emit('close', event)
         },
-        /**
+        /*
         * Emit click event when tag is clicked.
         */
         click(event: Event) {

--- a/packages/buefy-next/src/utils/MessageMixin.ts
+++ b/packages/buefy-next/src/utils/MessageMixin.ts
@@ -46,7 +46,7 @@ export default defineComponent({
         }
     },
     computed: {
-        /**
+        /*
          * Icon name (MDI) based on type.
          */
         computedIcon() {
@@ -83,7 +83,7 @@ export default defineComponent({
         }
     },
     methods: {
-        /**
+        /*
          * Close the Message and emit events.
          */
         close() {
@@ -95,7 +95,7 @@ export default defineComponent({
         click() {
             this.$emit('click')
         },
-        /**
+        /*
          * Set timer to auto close message
          */
         setAutoClose() {
@@ -109,7 +109,7 @@ export default defineComponent({
         },
         setDurationProgress() {
             if (this.progressBar || this.autoClose) {
-                /**
+                /*
                  * Runs every one second to set the duration passed before
                  * the alert will auto close to show it in the progress bar (Remaining Time)
                  */
@@ -123,7 +123,7 @@ export default defineComponent({
             }
         },
         resetDurationProgress() {
-            /**
+            /*
              * Wait until the component get closed and then reset
              **/
             setTimeout(() => {

--- a/packages/buefy-next/src/utils/ProviderParentMixin.ts
+++ b/packages/buefy-next/src/utils/ProviderParentMixin.ts
@@ -90,7 +90,7 @@ export default <
 
         if (hasFlag(flags, sorted)) {
             mixin.computed = {
-                /**
+                /*
                  * When items are added/removed sort them according to their position
                  */
                 sortedItems() {

--- a/packages/buefy-next/src/utils/config.ts
+++ b/packages/buefy-next/src/utils/config.ts
@@ -2,7 +2,7 @@ import type { App } from 'vue'
 
 import Color from './color'
 
-/**
+/*
  * Type that can be bound to `class` attribute in Vue.
  *
  * @remarks
@@ -17,14 +17,14 @@ export type VueClassAttribute =
     | (string | Record<string, boolean | undefined> | null | undefined)
     | (string | Record<string, boolean | undefined> | null | undefined)[]
 
-/**
+/*
  * Cancellable options for `Modal`.
  *
  * @public
  */
 export type ModalCancellableOption = 'escape' | 'x' | 'outside' | 'button'
 
-/**
+/*
  * Possible positions of notice components.
  *
  * @public
@@ -38,408 +38,408 @@ export const NOTICE_POSITIONS = [
     'is-bottom-left'
 ] as const
 
-/**
+/*
  * Position of notice components.
  *
  * @public
  */
 export type NoticePosition = typeof NOTICE_POSITIONS[number]
 
-/**
+/*
  * Scroll behavior for `Modal` and `Sidebar`.
  *
  * @public
  */
 export type ModalScrollOption = 'clip' | 'keep'
 
-/**
+/*
  * Label position for `Field`.
  *
  * @public
  */
 export type FieldLabelPosition = 'inside' | 'on-border'
 
-/**
+/*
  * Icon pack.
  *
  * @public
  */
 export interface IconPack {
-    /**
+    /*
      * Available sizes.
      * Maps size names to size values.
      */
     sizes: Record<string, string | null>
-    /** Icon prefix. */
+    /* Icon prefix. */
     iconPrefix?: string
 }
 
-/**
+/*
  * Buefy configuration.
  *
  * @public
  */
 export interface BuefyConfig {
-    /**
+    /*
      * Default container element.
      * Default value of `container` prop of `Dialog`, `Notification`,
      * `Snackbar`, and `Toast`.
      */
     defaultContainerElement?: string | null,
-    /**
+    /*
      * Default icon pack name.
      * "mdi" by default.
      */
     defaultIconPack: string,
-    /**
+    /*
      * Default icon component.
      * Default component that renders icons.
      * `<i>` by default.
      */
     defaultIconComponent?: string | null,
-    /**
+    /*
      * Default icon for previous buttons.
      * "chevron-left" by default.
      */
     defaultIconPrev: string,
-    /**
+    /*
      * Default icon for next buttons.
      * "chevron-right" by default.
      */
     defaultIconNext: string,
-    /**
+    /*
      * Default locale.
      * Default locale of the browser by default.
      */
     defaultLocale?: string | string[] | null,
-    /**
+    /*
      * Default confirm text on `Dialog`.
      * Default value of `confirm-text` prop of `Dialog`.
      */
     defaultDialogConfirmText?: string | null,
-    /**
+    /*
      * Default cancel text on `Dialog`.
      * Default value of `cancel-text` prop of `Dialog`.
      */
     defaultDialogCancelText?: string | null,
-    /**
+    /*
      * Default duration of `Snackbar` in milliseconds.
      * 3500 by default.
      */
     defaultSnackbarDuration: number,
-    /**
+    /*
      * Default position of `Snackbar`.
      * "is-bottom-right" by default.
      */
     defaultSnackbarPosition?: NoticePosition | null,
-    /**
+    /*
      * Default duration of `Toast` in milliseconds.
      * 2000 by default.
      */
     defaultToastDuration: number,
-    /**
+    /*
      * Default position of `Toast`.
      * "is-top" by default.
      */
     defaultToastPosition?: NoticePosition | null,
-    /**
+    /*
      * Default duration of `Notification` in milliseconds.
      * 2000 by default.
      */
     defaultNotificationDuration: number,
-    /**
+    /*
      * Default position of `Notification`.
      * "is-top-right" by default.
      */
     defaultNotificationPosition?: NoticePosition | null,
-    /**
+    /*
      * Default type of `Tooltip`.
      * "is-primary" by default.
      */
     defaultTooltipType: string,
-    /**
+    /*
      * Default delay of `Tooltip` in milliseconds.
      * No delay by default.
      */
     defaultTooltipDelay?: number | null,
-    /**
+    /*
      * Default delay of `Tooltip` to close in milliseconds.
      * No delay by default.
      */
     defaultTooltipCloseDelay?: number | null,
-    /**
+    /*
      * Default delay of `Sidebar` in milliseconds.
      * No delay by default.
      */
     defaultSidebarDelay?: number | null,
-    /**
+    /*
      * Default autocomplete attribute of `Input`.
      * "on" by default.
      */
     defaultInputAutocomplete: string,
-    /**
+    /*
      * Default date formatter.
      * Default function that `dateFormatter` prop of `Datepicker` uses.
      * Buefy provides a default implementation if omitted.
      */
     defaultDateFormatter?: ((date: Date) => string) | null,
-    /**
+    /*
      * Default date parser.
      * Default function that `dateParser` prop of `Datepicker` uses.
      * Buefy provides a default implementation if omitted.
      */
     defaultDateParser?: ((date: string) => Date | null) | null,
-    /**
+    /*
      * Default date creator.
      * Default function that `dateCreator` prop of `Datepicker` uses.
      * Buefy provides a default implementation if omitted.
      */
     defaultDateCreator?: (() => Date) | null,
-    /**
+    /*
      * Default time creator.
      * Default function that `timeCreator` prop of `Clockpicker` and
      * `Timepicker` uses.
      * Buefy provides a default implementation if omitted.
      */
     defaultTimeCreator?: (() => Date) | null,
-    /**
+    /*
      * Default day names.
      * Default value of `day-names` prop of `Datepicker`.
      * Retrieves from the default locale by default.
      */
     defaultDayNames?: string[] | null,
-    /**
+    /*
      * Default month names.
      * Default value of `month-names` prop of `Datepicker`.
      * Retrieves from the default locale by default.
      */
     defaultMonthNames?: string[] | null,
-    /**
+    /*
      * Default first day of week.
      * Default value of `first-day-of-week` prop of `Datepicker`.
      * 0 (Sunday) by default.
      */
     defaultFirstDayOfWeek?: number | null,
-    /**
+    /*
      * Default unselectable days of week.
      * Default value of `unselectable-days-of-week` prop of `Datepicker`.
      * No unselectable days of week if omitted.
      */
     defaultUnselectableDaysOfWeek?: number[] | null,
-    /**
+    /*
      * Default time formatter.
      * Default function that `timeFormatter` prop of `Clockpicker` and
      * `Timepicker` uses.
      * Buefy provides a default implementation if omitted.
      */
     defaultTimeFormatter?: ((date: Date) => string) | null,
-    /**
+    /*
      * Default time parser.
      * Default function that `timeParser` prop of `Clockpicker` and
      * `Timepicker` uses.
      * Buefy provides a default implementation if omitted.
      */
     defaultTimeParser?: ((date: string) => Date | null) | null,
-    /**
+    /*
      * Default datetime formatter used by `Datetimepicker`.
      */
     defaultDatetimeFormatter?: ((date: Date) => string) | null,
-    /**
+    /*
      * Default datetime parser used by `Datetimepicker`.
      */
     defaultDatetimeParser?: ((date: string) => Date | null) | null,
-    /**
+    /*
      * Default datetime creator.
      * Default function that `datetimeCreator` prop of `Datetimepicker` uses.
      */
     defaultDatetimeCreator?: ((date: Date) => Date) | null,
-    /**
+    /*
      * Default "Hours" label on `Clockpicker`.
      */
     defaultClockpickerHoursLabel?: string | null,
-    /**
+    /*
      * Default "Minutes" label on `Clockpicker`.
      */
     defaultClockpickerMinutesLabel?: string | null,
-    /**
+    /*
      * Default color formatter.
      * Default function that the `colorFormatter` prop of `Colorpicker` calls.
      * Buefy provides a default implementation if omitted.
      */
     defaultColorFormatter?: ((color: Color) => string) | null,
-    /**
+    /*
      * Default color parser.
      * Default function that the `colorParser` prop of `Colorpicker` calls.
      * Buefy provides a default implementation if omitted.
      */
     defaultColorParser?: ((color: string) => Color | null) | null,
-    /**
+    /*
      * Default cancellable options of `Modal`.
      * `['escape', 'x', 'outside', 'button']` by default.
      */
     defaultModalCanCancel: ModalCancellableOption[],
-    /**
+    /*
      * Default scroll behavior of `Modal`.
      * Default value of `scroll` prop of `Modal` and `Sidebar`.
      * 'clip' by default.
      */
     defaultModalScroll?: ModalScrollOption | null,
-    /**
+    /*
      * Default mobile native behavior of `Datepicker`.
      * Default value of `mobile-native` prop of `Datepicker`.
      * `true` by default.
      */
     defaultDatepickerMobileNative: boolean,
-    /**
+    /*
      * Default mobile native behavior of `Timepicker`.
      * Default value of `mobile-native` prop of `Timepicker`.
      * `true` by default.
      */
     defaultTimepickerMobileNative: boolean,
-    /**
+    /*
      * Default mobile modal behavior of `Timepicker`.
      * Default value of `mobile-modal` prop of `Timepicker`.
      * `true` by default.
      */
     defaultTimepickerMobileModal: boolean,
-    /**
+    /*
      * Default queue behavior of `Notice`.
      * Default value of `queue` prop of `Notice`.
      * `true` by default.
      */
     defaultNoticeQueue: boolean,
-    /**
+    /*
      * Default counter behavior of `Input`.
      * Default value of `has-counter` prop of `Input`.
      * `true` by default.
      */
     defaultInputHasCounter: boolean,
-    /**
+    /*
      * Whether `class`, `style`, and `id` are applied to the root element in
      * components that are affected by Vue 3 change in fallthgourh beahvior.
      * See: https://github.com/ntohq/buefy-next/issues/16
      */
     defaultCompatFallthrough: boolean,
-    /**
+    /*
      * Default counter behavior of `Taginput`.
      * Default value of `has-counter` prop of `Taginput`.
      * `true` by default.
      */
     defaultTaginputHasCounter: boolean,
-    /**
+    /*
      * Default HTML5 validation behavior of `Input`.
      * Default value of `use-html5-validation` prop of form controls.
      * `true` by default.
      */
     defaultUseHtml5Validation: boolean,
-    /**
+    /*
      * Default mobile modal behavior of `Dropdown`.
      * Default value of `mobile-modal` prop of `Dropdown`.
      * `true` by default.
      */
     defaultDropdownMobileModal: boolean,
-    /**
+    /*
      * Default label position of `Field`.
      * Default value of `label-position` prop of `Field`.
      * `null` by default.
      */
     defaultFieldLabelPosition?: FieldLabelPosition | null,
-    /**
+    /*
      * Default years range of `Datepicker`.
      * Default value of `years-range` prop of `Datepicker`.
      * `[-100, 10]` by default.
      */
     defaultDatepickerYearsRange: [number, number],
-    /**
+    /*
      * Default nearby month days behavior of `Datepicker`.
      * Default value of `nearby-month-days` prop of `Datepicker`.
      * `true` by default.
      */
     defaultDatepickerNearbyMonthDays: boolean,
-    /**
+    /*
      * Default nearby selectable month days behavior of `Datepicker`.
      * Default value of `nearby-selectable-month-days` prop of `Datepicker`.
      * `false` by default.
      */
     defaultDatepickerNearbySelectableMonthDays: boolean,
-    /**
+    /*
      * Default show week number behavior of `Datepicker`.
      * Default value of `show-week-number` prop of `Datepicker`.
      * `false` by default.
      */
     defaultDatepickerShowWeekNumber: boolean,
-    /**
+    /*
      * Default week number clickable behavior of `Datepicker`.
      * Default value of `week-number-clickable` prop of `Datepicker`.
      * `false` by default.
      */
     defaultDatepickerWeekNumberClickable: boolean,
-    /**
+    /*
      * Default mobile modal behavior of `Datepicker`.
      * Default value of `mobile-modal` prop of `Datepicker` and `Clockpicker`.
      * `true` by default.
      */
     defaultDatepickerMobileModal: boolean,
-    /**
+    /*
      * Default trap focus behavior of `Modal`.
      * Default value of `trap-focus` prop of `Colorpicker`, `Datepicker`,
      * `Dialog`, `Dropdown`, and `Modal`.
      * `true` by default.
      */
     defaultTrapFocus: boolean,
-    /**
+    /*
      * Default autofocus behavior of `Modal`.
      * Default value of `autoFocus` prop of `Modal`.
      * `true` by default.
      */
     defaultAutoFocus: boolean,
-    /**
+    /*
      * Default rounded flag for `Button`.
      * Default value of `rounded` prop of `Button`.
      * `false` by default.
      */
     defaultButtonRounded: boolean,
-    /**
+    /*
      * Default rounded flag for `Switch`.
      * Default value of `rounded` prop of `Switch`.
      * `true` by default.
      */
     defaultSwitchRounded: boolean,
-    /**
+    /*
      * Default interval of `Carousel` in milliseconds.
      * 3500 by default.
      */
     defaultCarouselInterval: number,
-    /**
+    /*
      * Default expanded flag for `Tabs`.
      * Default value of `expanded` prop of `Tabs`.
      * `false` by default.
      */
     defaultTabsExpanded: boolean,
-    /**
+    /*
      * Default animated flag for `Tabs`.
      * Default value of `animated` prop of `Tabs`.
      * `true` by default.
      */
     defaultTabsAnimated: boolean,
-    /**
+    /*
      * Default class(es) applied to tab elements in `Tabs`.
      * `null` by default.
      */
     defaultTabsType?: VueClassAttribute | null,
-    /**
+    /*
      * Default status icon flag for form controls (`Input`).
      * `true` by default.
      */
     defaultStatusIcon: boolean,
-    /**
+    /*
      * Default promise behavior of programmatically opened `Dialog`.
      * Programmatically opened `Dialog`s return a `Promise` that resolves
      * when the `Dialog` is closed, if this config is `true`.
      * `false` by default.
      */
     defaultProgrammaticPromise: boolean,
-    /**
+    /*
      * Default tags for link elements.
      * The following tags are accepted by default:
      * - a
@@ -453,62 +453,62 @@ export interface BuefyConfig {
      * - NLink
      */
     defaultLinkTags: string[],
-    /**
+    /*
      * Default fallback extension or location for WebP images.
      * It is interpretted as an extension, if it starts with a dot (".").
      * Other strings are interpretted as paths to substitute images.
      * No fallback by default.
      */
     defaultImageWebpFallback?: string | null,
-    /**
+    /*
      * Default lazy loading behavior of `Image`.
      * Default value of `lazy` prop of `Image`.
      * `true` by default.
      */
     defaultImageLazy: boolean,
-    /**
+    /*
      * Default responsive behavior of `Image`.
      * Default value of `responsive` prop of `Image`.
      * `true` by default.
      */
     defaultImageResponsive: boolean,
-    /**
+    /*
      * Default ratio of `Image`.
      * Default value of `ratio` prop of `Image`.
      * No ration is applied by default.
      */
     defaultImageRatio?: number | null,
-    /**
+    /*
      * Default srcset formatter of `Image`.
      * Default function that `srcset-formatter` prop of `Image` uses.
      * Buefy provides a default implementation if omitted.
      */
     defaultImageSrcsetFormatter?: ((src: string, size: number) => string) | null,
-    /**
+    /*
      * Default tag of `Breadcrumb` items.
      * Default value of `tag` prop of `BreadcrumbItem`.
      * "a" by default.
      */
     defaultBreadcrumbTag: string,
-    /**
+    /*
      * Default alignment of `Breadcrumb`.
      * Default value of `align` prop of `Breadcrumb`.
      * "is-left" by default.
      */
     defaultBreadcrumbAlign: string,
-    /**
+    /*
      * Default separator of `Breadcrumb`.
      * Default value of `separator` prop of `Breadcrumb`.
      * No separator (an empty string) by default.
      */
     defaultBreadcrumbSeparator: string,
-    /**
+    /*
      * Default size of `Breadcrumb`.
      * Default value of `size` prop of `Breadcrumb`.
      * "is-medium" by default.
      */
     defaultBreadcrumbSize: string,
-    /**
+    /*
      * Custom icon packs.
      * No custom icon packs by default.
      */
@@ -603,7 +603,7 @@ let config: BuefyConfig = {
     customIconPacks: null
 }
 
-/**
+/*
  * {@link BuefyConfig} with all the properties optional.
  *
  * @public

--- a/packages/buefy-next/src/utils/helpers.ts
+++ b/packages/buefy-next/src/utils/helpers.ts
@@ -31,7 +31,7 @@ export type ExtractComponentData<T> = T extends { new (...args: any[]): infer U 
         : Record<string, never>
     : Record<string, never>
 
-/**
+/*
  * +/- function to native math sign
  *
  * @internal
@@ -42,7 +42,7 @@ function signPoly(value: number): number {
 }
 export const sign = Math.sign || signPoly
 
-/**
+/*
  * Checks if the flag is set
  * @param val
  * @param flag
@@ -54,7 +54,7 @@ export function hasFlag(val: number, flag: number): boolean {
     return (val & flag) === flag
 }
 
-/**
+/*
  * Native modulo bug with negative numbers
  * @param n
  * @param mod
@@ -66,7 +66,7 @@ export function mod(n: number, mod: number): number {
     return ((n % mod) + mod) % mod
 }
 
-/**
+/*
  * Asserts a value is beetween min and max
  * @param val
  * @param min
@@ -79,7 +79,7 @@ export function bound(val: number, min: number, max: number): number {
     return Math.max(min, Math.min(max, val))
 }
 
-/**
+/*
  * Get value of an object property/path even if it's nested
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -87,7 +87,7 @@ export function getValueByPath(obj: any, path: string): any {
     return path.split('.').reduce((o, i) => o ? o[i] : null, obj)
 }
 
-/**
+/*
  * Extension of indexOf method by equality function if specified
  *
  * @internal
@@ -117,7 +117,7 @@ export function indexOf<T>(
 // https://stackoverflow.com/questions/61132262/typescript-deep-partial
 type DeepPartial<T> = { [K in keyof T]?: DeepPartial<T[K]> }
 
-/**
+/*
  * Merge function to replace Object.assign with deep merging possibility
  *
  * @internal
@@ -156,7 +156,7 @@ const mergeFn = <T>(
 }
 export const merge = mergeFn
 
-/**
+/*
  * Mobile detection
  * https://www.abeautifulsite.net/detecting-mobile-devices-with-javascript
  *
@@ -233,7 +233,7 @@ export function isVueComponent(c: unknown): c is ComponentPublicInstance {
         (c as ComponentPublicInstance).$.vnode != null
 }
 
-/**
+/*
  * Escape regex characters
  * http://stackoverflow.com/a/6969486
  *
@@ -245,7 +245,7 @@ export function escapeRegExpChars(value: string | null | undefined): string | nu
     // eslint-disable-next-line
     return value.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&')
 }
-/**
+/*
  * Remove accents/diacritics in a string in JavaScript
  * https://stackoverflow.com/a/37511463
  *
@@ -303,7 +303,7 @@ export function toCssWidth(width: number | string | undefined): string | null {
     return width === undefined ? null : (isNaN(+width) ? `${width}` : width + 'px')
 }
 
-/**
+/*
  * Return month names according to a specified locale
  * @param  {String} locale A bcp47 localerouter. undefined will use the user browser locale
  * @param  {String} format long (ex. March), short (ex. Mar) or narrow (M)
@@ -322,7 +322,7 @@ export function getMonthNames(locale?: string | string[], format: Intl.DateTimeF
     return dates.map((d) => dtf.format(d))
 }
 
-/**
+/*
  * Return weekday names according to a specified locale
  * @param  {String} locale A bcp47 localerouter. undefined will use the user browser locale
  * @param  {String} format long (ex. Thursday), short (ex. Thu) or narrow (T)
@@ -340,7 +340,7 @@ export function getWeekdayNames(locale?: string | string[], format: Intl.DateTim
     return dates.map((d) => dtf.format(d))
 }
 
-/**
+/*
  * Accept a regex with group names and return an object
  * ex. matchWithGroups(/((?!=<year>)\d+)\/((?!=<month>)\d+)\/((?!=<day>)\d+)/, '2000/12/25')
  * will return { year: 2000, month: 12, day: 25 }
@@ -375,7 +375,7 @@ export function matchWithGroups(pattern: string, str: string): Record<string, st
         }, {} as Record<string, string | null>)
 }
 
-/**
+/*
  * Based on
  * https://github.com/fregante/supports-webp
  *
@@ -398,7 +398,7 @@ export function isCustomElement(vm: Pick<ComponentPublicInstance, '$root'>) {
 
 export const isDefined = <T>(d: T | undefined): d is T => d !== undefined
 
-/**
+/*
  * Checks if a value is null or undefined.
  * Based on
  * https://github.com/lodash/lodash/blob/master/isNil.js
@@ -475,13 +475,13 @@ export function copyAppContext(src: App, dest: App) {
     }
 }
 
-/** Options for `translateTouchAsDragEvent`. */
+/* Options for `translateTouchAsDragEvent`. */
 export interface TranslateTouchAsDragEventOptions {
     type: 'dragstart' | 'dragend' | 'drop' | 'dragover' | 'dragleave'
     target?: Element
 }
 
-/**
+/*
  * Translates a touch event as a drag event.
  *
  * `event` must be a touch event.

--- a/packages/buefy-next/src/utils/icons.ts
+++ b/packages/buefy-next/src/utils/icons.ts
@@ -1,13 +1,13 @@
 import config, { type IconPack } from '../utils/config'
 import { merge } from '../utils/helpers'
 
-/**
+/*
  * Internally used {@link IconPack} type.
  *
  * @internal
  */
 export type InternalIconPack = IconPack & {
-    /** Maps icon names to equivalent ones in MDI. */
+    /* Maps icon names to equivalent ones in MDI. */
     internalIcons: Record<string, string>
 }
 

--- a/packages/buefy-next/src/utils/vue-augmentation.ts
+++ b/packages/buefy-next/src/utils/vue-augmentation.ts
@@ -18,9 +18,9 @@ import ConfigComponent from './ConfigComponent'
 // Augments the global property with `$buefy`.
 // https://vuejs.org/guide/typescript/options-api.html#augmenting-global-properties
 declare module '@vue/runtime-core' {
-    /** @public */
+    /* @public */
     interface ComponentCustomProperties {
-        /** Global Buefy API. */
+        /* Global Buefy API. */
         $buefy: {
             config: typeof ConfigComponent,
             globalNoticeInterval?: ReturnType<typeof setTimeout>,

--- a/packages/docs/src/pages/extensions/cleavejs/examples/ExFormat.vue
+++ b/packages/docs/src/pages/extensions/cleavejs/examples/ExFormat.vue
@@ -42,7 +42,7 @@
         _vCleave: Cleave
     }
 
-    /**
+    /*
      * We add a new instance of Cleave when the element
      * is bound and destroy it when it's unbound.
      */

--- a/packages/docs/src/pages/extensions/sortablejs/examples/ExSimple.vue
+++ b/packages/docs/src/pages/extensions/sortablejs/examples/ExSimple.vue
@@ -56,7 +56,7 @@
         })
     }
 
-    /**
+    /*
      * We add a new instance of Sortable when the element
      * is bound or updated, and destroy it when it's unbound.
      */


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #446, [#415](https://github.com/ntohq/buefy-next/issues/415)
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes
- Replaces all comments that start with `/**` with `/*`
- Suppresses all `api-extractor` forgotten export and missing release tag warnings
