### PR TITLE
fix clockpicker: editable prop does not work #460

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Buefy-next 0.2.1 is now compiled with Vue 3.4.13, so the recommended Vue version
 * [#434](https://github.com/ntohq/buefy-next/issues/434) The multi column sorting feature of `Table` did not work since Buefy-next v0.2.0.
 * [#460](https://github.com/ntohq/buefy-next/issues/460) The `editable` prop of `Clockpicker` did not work (thanks @Moritz-Schmidt)
 * [#461](https://github.com/ntohq/buefy-next/pull/461) The initial value of `Clockpicker` was not rendered (thanks @Moritz-Schmidt)
+* [#461](https://github.com/ntohq/buefy-next/pull/461) `Clockpicker` did not work on a mobile device
 
 ### Others
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Buefy-next 0.2.1 is now compiled with Vue 3.4.13, so the recommended Vue version
 * [#429](https://github.com/ntohq/buefy-next/issues/429) `Numberinput` may have accepted an invalid number as valid with Vue 3.4.28 or higher.
 * [#434](https://github.com/ntohq/buefy-next/issues/434) The multi column sorting feature of `Table` did not work since Buefy-next v0.2.0.
 * [#460](https://github.com/ntohq/buefy-next/issues/460) The `editable` prop of `Clockpicker` did not work (thanks @Moritz-Schmidt)
+* [#461](https://github.com/ntohq/buefy-next/pull/461) The initial value of `Clockpicker` was not rendered (thanks @Moritz-Schmidt)
 
 ### Others
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Buefy-next 0.2.1 is now compiled with Vue 3.4.13, so the recommended Vue version
   `SlotComponent` which is internally used by `Table`, and `Tabs` ceased adding the update hook to the component specified to the `component` prop, and dropped the `event` prop.
 * [#429](https://github.com/ntohq/buefy-next/issues/429) `Numberinput` may have accepted an invalid number as valid with Vue 3.4.28 or higher.
 * [#434](https://github.com/ntohq/buefy-next/issues/434) The multi column sorting feature of `Table` did not work since Buefy-next v0.2.0.
+* [#460](https://github.com/ntohq/buefy-next/issues/460) The `editable` prop of `Clockpicker` did not work (thanks @Moritz-Schmidt)
 
 ### Others
 

--- a/packages/buefy-next/src/components/clockpicker/Clockpicker.vue
+++ b/packages/buefy-next/src/components/clockpicker/Clockpicker.vue
@@ -326,15 +326,15 @@ export default defineComponent({
             }
         },
         onEditDone(event: KeyboardEvent) {
-            if (!this.editable) return;
+            if (!this.editable) return
 
             if (event.key === 'Enter') {
-                this.isEditing = false;
-                this.onBlur();
+                this.isEditing = false
+                this.onBlur()
             } else if (event.key === 'Escape') {
-                this.isEditing = false;
+                this.isEditing = false
                 // Revert to the previous value without parsing the input
-                this.localInputValue = this.formatValue(this.computedValue) || '';
+                this.localInputValue = this.formatValue(this.computedValue) || ''
             }
         }
     },

--- a/packages/buefy-next/src/components/clockpicker/Clockpicker.vue
+++ b/packages/buefy-next/src/components/clockpicker/Clockpicker.vue
@@ -20,7 +20,6 @@
                     <b-input
                         ref="input"
                         autocomplete="off"
-                        :type="inputType"
                         :value="editable ? localInputValue : formatValue(computedValue)"
                         :placeholder="placeholder"
                         :size="size"
@@ -219,10 +218,6 @@ export default defineComponent({
         minutesLabel: {
             type: String,
             default: () => config.defaultClockpickerMinutesLabel || 'Min'
-        },
-        inputType: {
-            type: String,
-            default: 'text'
         }
     },
     data() {

--- a/packages/buefy-next/src/components/clockpicker/Clockpicker.vue
+++ b/packages/buefy-next/src/components/clockpicker/Clockpicker.vue
@@ -183,6 +183,7 @@ import BInput from '../input/Input.vue'
 import BClockpickerFace from './ClockpickerFace.vue'
 
 type BDropdownInstance = InstanceType<typeof BDropdown>
+type BInputInstance = InstanceType<typeof BInput>
 
 const outerPadding = 12
 
@@ -330,6 +331,9 @@ export default defineComponent({
                 this.onBlur()
             }
         }
+    },
+    mounted() {
+        (this.$refs.input as BInputInstance).newValue = this.formatValue(this.computedValue) || ''
     }
 })
 </script>

--- a/packages/buefy-next/src/components/clockpicker/Clockpicker.vue
+++ b/packages/buefy-next/src/components/clockpicker/Clockpicker.vue
@@ -33,12 +33,12 @@
                         v-bind="fallthroughAttrs"
                         :use-html5-validation="useHtml5Validation"
                         @click="onInputClick"
-                        @keyup.enter="toggle(true)"
+                        @keyup.enter="(event: KeyboardEvent) => {toggle(true); onEditDone(event)}"
+                        @keyup.escape="onEditDone"
                         @input="onInput"
                         @change="onChange($event.target.value)"
                         @focus="handleOnFocus"
                         @blur="checkHtml5Validity()"
-                        @keydown="onKeydown"
                     />
                 </slot>
             </template>
@@ -329,7 +329,7 @@ export default defineComponent({
                 this.localInputValue = this.formatValue(this.computedValue)
             }
         },
-        onKeydown(event: KeyboardEvent) {
+        onEditDone(event: KeyboardEvent) {
             if ((event.key === 'Enter' || event.key === 'Escape') && this.editable) {
                 this.isEditing = false
                 this.onBlur()

--- a/packages/buefy-next/src/components/clockpicker/Clockpicker.vue
+++ b/packages/buefy-next/src/components/clockpicker/Clockpicker.vue
@@ -20,12 +20,11 @@
                     <b-input
                         ref="input"
                         autocomplete="off"
-                        :value="formatValue(computedValue)"
+                        :model-value="formatValue(computedValue)"
                         :placeholder="placeholder"
                         :size="size"
                         :icon="icon"
                         :icon-pack="iconPack"
-                        :lazy="editable"
                         :loading="loading"
                         :disabled="disabledOrUndefined"
                         :readonly="!editable"
@@ -34,7 +33,7 @@
                         :use-html5-validation="useHtml5Validation"
                         @click="onInputClick"
                         @keyup.enter="toggle(true)"
-                        @update:model-value="(value) => onChange(value as string)"
+                        @change="onChange($event.target.value)"
                         @focus="handleOnFocus"
                         @blur="checkHtml5Validity()"
                     />
@@ -149,7 +148,7 @@
             ref="input"
             type="time"
             autocomplete="off"
-            :value="formatHHMMSS(computedValue)"
+            :model-value="formatHHMMSS(computedValue)"
             :placeholder="placeholder"
             :size="size"
             :icon="icon"
@@ -182,7 +181,6 @@ import BInput from '../input/Input.vue'
 import BClockpickerFace from './ClockpickerFace.vue'
 
 type BDropdownInstance = InstanceType<typeof BDropdown>
-type BInputInstance = InstanceType<typeof BInput>
 
 const outerPadding = 12
 
@@ -294,12 +292,6 @@ export default defineComponent({
             if ((this.$refs.dropdown as BDropdownInstance).isActive) {
                 event.stopPropagation()
             }
-        }
-    },
-    mounted() {
-        // this.$refs.input may be undefined if the `inline` prop is true
-        if (this.$refs.input != null) {
-            (this.$refs.input as BInputInstance).newValue = this.formatValue(this.computedValue) || ''
         }
     }
 })

--- a/packages/buefy-next/src/components/clockpicker/Clockpicker.vue
+++ b/packages/buefy-next/src/components/clockpicker/Clockpicker.vue
@@ -326,9 +326,15 @@ export default defineComponent({
             }
         },
         onEditDone(event: KeyboardEvent) {
-            if ((event.key === 'Enter' || event.key === 'Escape') && this.editable) {
-                this.isEditing = false
-                this.onBlur()
+            if (!this.editable) return;
+
+            if (event.key === 'Enter') {
+                this.isEditing = false;
+                this.onBlur();
+            } else if (event.key === 'Escape') {
+                this.isEditing = false;
+                // Revert to the previous value without parsing the input
+                this.localInputValue = this.formatValue(this.computedValue) || '';
             }
         }
     },

--- a/packages/buefy-next/src/components/clockpicker/Clockpicker.vue
+++ b/packages/buefy-next/src/components/clockpicker/Clockpicker.vue
@@ -38,7 +38,7 @@
                         @input="onInput"
                         @change="onChange($event.target.value)"
                         @focus="handleOnFocus"
-                        @blur="checkHtml5Validity()"
+                        @blur="onBlur()"
                     />
                 </slot>
             </template>
@@ -167,7 +167,7 @@
             @keyup.enter="toggle(true)"
             @change="onChangeNativePicker"
             @focus="handleOnFocus"
-            @blur="onBlur() && checkHtml5Validity()"
+            @blur="onBlur()"
         />
     </div>
 </template>
@@ -277,7 +277,7 @@ export default defineComponent({
         computedValue: {
             handler(val) {
                 if (!this.isEditing) {
-                    this.localInputValue = this.formatValue(val)
+                    this.localInputValue = this.formatValue(val) || ''
                 }
             },
             immediate: true
@@ -326,7 +326,7 @@ export default defineComponent({
                 this.computedValue = date
             } else {
                 // Reset to last valid value
-                this.localInputValue = this.formatValue(this.computedValue)
+                this.localInputValue = this.formatValue(this.computedValue) || ''
             }
         },
         onEditDone(event: KeyboardEvent) {

--- a/packages/buefy-next/src/components/clockpicker/Clockpicker.vue
+++ b/packages/buefy-next/src/components/clockpicker/Clockpicker.vue
@@ -297,7 +297,10 @@ export default defineComponent({
         }
     },
     mounted() {
-        (this.$refs.input as BInputInstance).newValue = this.formatValue(this.computedValue) || ''
+        // this.$refs.input may be undefined if the `inline` prop is true
+        if (this.$refs.input != null) {
+            (this.$refs.input as BInputInstance).newValue = this.formatValue(this.computedValue) || ''
+        }
     }
 })
 </script>

--- a/packages/buefy-next/src/components/clockpicker/Clockpicker.vue
+++ b/packages/buefy-next/src/components/clockpicker/Clockpicker.vue
@@ -20,7 +20,8 @@
                     <b-input
                         ref="input"
                         autocomplete="off"
-                        :value="formatValue(computedValue)"
+                        :type="inputType"
+                        :value="editable ? localInputValue : formatValue(computedValue)"
                         :placeholder="placeholder"
                         :size="size"
                         :icon="icon"
@@ -33,9 +34,11 @@
                         :use-html5-validation="useHtml5Validation"
                         @click="onInputClick"
                         @keyup.enter="toggle(true)"
+                        @input="onInput"
                         @change="onChange($event.target.value)"
                         @focus="handleOnFocus"
                         @blur="checkHtml5Validity()"
+                        @keydown="onKeydown"
                     />
                 </slot>
             </template>
@@ -216,13 +219,19 @@ export default defineComponent({
         minutesLabel: {
             type: String,
             default: () => config.defaultClockpickerMinutesLabel || 'Min'
+        },
+        inputType: {
+            type: String,
+            default: 'text'
         }
     },
     data() {
         return {
             isSelectingHour: true,
             isDragging: false,
-            _isClockpicker: true
+            _isClockpicker: true,
+            localInputValue: null as string | null,
+            isEditing: false
         }
     },
     computed: {
@@ -264,6 +273,16 @@ export default defineComponent({
             return this.isSelectingHour ? this.isHourDisabled : this.isMinuteDisabled
         }
     },
+    watch: {
+        computedValue: {
+            handler(val) {
+                if (!this.isEditing) {
+                    this.localInputValue = this.formatValue(val)
+                }
+            },
+            immediate: true
+        }
+    },
     methods: {
         onClockInput(value: number) {
             if (this.isSelectingHour) {
@@ -291,6 +310,29 @@ export default defineComponent({
         onInputClick(event: MouseEvent) {
             if ((this.$refs.dropdown as BDropdownInstance).isActive) {
                 event.stopPropagation()
+            }
+        },
+        onInput(event: Event) {
+            if (!this.editable) return
+            this.isEditing = true
+            this.localInputValue = (event.target as HTMLInputElement).value
+        },
+        onBlur() {
+            this.checkHtml5Validity()
+            if (!this.editable) return
+
+            const date = this.timeParser(this.localInputValue, this)
+            if (date && !isNaN(date.valueOf())) {
+                this.computedValue = date
+            } else {
+                // Reset to last valid value
+                this.localInputValue = this.formatValue(this.computedValue)
+            }
+        },
+        onKeydown(event: KeyboardEvent) {
+            if ((event.key === 'Enter' || event.key === 'Escape') && this.editable) {
+                this.isEditing = false
+                this.onBlur()
             }
         }
     }

--- a/packages/buefy-next/src/components/clockpicker/Clockpicker.vue
+++ b/packages/buefy-next/src/components/clockpicker/Clockpicker.vue
@@ -20,11 +20,12 @@
                     <b-input
                         ref="input"
                         autocomplete="off"
-                        :value="editable ? localInputValue : formatValue(computedValue)"
+                        :value="formatValue(computedValue)"
                         :placeholder="placeholder"
                         :size="size"
                         :icon="icon"
                         :icon-pack="iconPack"
+                        :lazy="editable"
                         :loading="loading"
                         :disabled="disabledOrUndefined"
                         :readonly="!editable"
@@ -32,12 +33,10 @@
                         v-bind="fallthroughAttrs"
                         :use-html5-validation="useHtml5Validation"
                         @click="onInputClick"
-                        @keyup.enter="(event: KeyboardEvent) => {toggle(true); onEditDone(event)}"
-                        @keyup.escape="onEditDone"
-                        @input="onInput"
-                        @change="onChange($event.target.value)"
+                        @keyup.enter="toggle(true)"
+                        @update:model-value="(value) => onChange(value as string)"
                         @focus="handleOnFocus"
-                        @blur="onBlur()"
+                        @blur="checkHtml5Validity()"
                     />
                 </slot>
             </template>
@@ -166,7 +165,7 @@
             @keyup.enter="toggle(true)"
             @change="onChangeNativePicker"
             @focus="handleOnFocus"
-            @blur="onBlur()"
+            @blur="onBlur() && checkHtml5Validity()"
         />
     </div>
 </template>
@@ -225,9 +224,7 @@ export default defineComponent({
         return {
             isSelectingHour: true,
             isDragging: false,
-            _isClockpicker: true,
-            localInputValue: '' as string,
-            isEditing: false
+            _isClockpicker: true
         }
     },
     computed: {
@@ -269,16 +266,6 @@ export default defineComponent({
             return this.isSelectingHour ? this.isHourDisabled : this.isMinuteDisabled
         }
     },
-    watch: {
-        computedValue: {
-            handler(val) {
-                if (!this.isEditing) {
-                    this.localInputValue = this.formatValue(val) || ''
-                }
-            },
-            immediate: true
-        }
-    },
     methods: {
         onClockInput(value: number) {
             if (this.isSelectingHour) {
@@ -306,35 +293,6 @@ export default defineComponent({
         onInputClick(event: MouseEvent) {
             if ((this.$refs.dropdown as BDropdownInstance).isActive) {
                 event.stopPropagation()
-            }
-        },
-        onInput(event: Event) {
-            if (!this.editable) return
-            this.isEditing = true
-            this.localInputValue = (event.target as HTMLInputElement).value
-        },
-        onBlur() {
-            this.checkHtml5Validity()
-            if (!this.editable) return
-
-            const date = this.timeParser(this.localInputValue, this)
-            if (date && !isNaN(date.valueOf())) {
-                this.computedValue = date
-            } else {
-                // Reset to last valid value
-                this.localInputValue = this.formatValue(this.computedValue) || ''
-            }
-        },
-        onEditDone(event: KeyboardEvent) {
-            if (!this.editable) return
-
-            if (event.key === 'Enter') {
-                this.isEditing = false
-                this.onBlur()
-            } else if (event.key === 'Escape') {
-                this.isEditing = false
-                // Revert to the previous value without parsing the input
-                this.localInputValue = this.formatValue(this.computedValue) || ''
             }
         }
     },

--- a/packages/buefy-next/src/components/clockpicker/Clockpicker.vue
+++ b/packages/buefy-next/src/components/clockpicker/Clockpicker.vue
@@ -230,7 +230,7 @@ export default defineComponent({
             isSelectingHour: true,
             isDragging: false,
             _isClockpicker: true,
-            localInputValue: null as string | null,
+            localInputValue: '' as string,
             isEditing: false
         }
     },


### PR DESCRIPTION
The problem was probably that the input value handling in Vue 2 was less strict. In Vue 2, the DOM input value could temporarily diverge from the model, allowing smooth typing. In Vue 3, the input value is always kept in sync with the model, so formatting or parsing on every input event can disrupt user input. The solution is to track a local input state and only update/format the model when editing is complete (on blur or Enter).

Fixes #460 

## Proposed Changes
- Added `localInputValue` and `isEditing` to manage the raw input state when editable is true.
- The input field now displays `localInputValue` while editing, instead of immediately formatting the value.
- Added `onInput`, `onBlur`, and `onKeydown` handlers to control when the input is parsed and committed to the model.
- The model is only updated (and the value formatted) when the input loses focus or the user presses Enter/Escape.
- This prevents premature formatting and allows uninterrupted editing of partial time strings, especially for 12-hour formats.